### PR TITLE
feat(bigquery): fetch labels for dataset and table resources

### DIFF
--- a/core/provider/service.go
+++ b/core/provider/service.go
@@ -525,16 +525,16 @@ func (s *Service) getResources(ctx context.Context, p *domain.Provider) ([]*doma
 	for _, r := range flattenedProviderResources {
 		for _, er := range existingGuardianResources {
 			if er.URN == r.URN {
-				existingMetadata := er.Details
-				if existingMetadata != nil {
+				existingDetails := er.Details
+				if existingDetails != nil {
 					if r.Details != nil {
-						for key, value := range existingMetadata {
+						for key, value := range existingDetails {
 							if _, ok := r.Details[key]; !ok {
 								r.Details[key] = value
 							}
 						}
 					} else {
-						r.Details = existingMetadata
+						r.Details = existingDetails
 					}
 				}
 

--- a/core/provider/service.go
+++ b/core/provider/service.go
@@ -525,8 +525,7 @@ func (s *Service) getResources(ctx context.Context, p *domain.Provider) ([]*doma
 	for _, r := range flattenedProviderResources {
 		for _, er := range existingGuardianResources {
 			if er.URN == r.URN {
-				existingDetails := er.Details
-				if existingDetails != nil {
+				if existingDetails := er.Details; existingDetails != nil {
 					if r.Details != nil {
 						for key, value := range existingDetails {
 							if _, ok := r.Details[key]; !ok {

--- a/core/provider/service_test.go
+++ b/core/provider/service_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/goto/guardian/core/provider"
 	providermocks "github.com/goto/guardian/core/provider/mocks"
 	"github.com/goto/guardian/domain"
@@ -349,20 +351,77 @@ func (s *ServiceTestSuite) TestFetchResources() {
 	})
 
 	s.Run("should upsert all resources on success", func() {
-		s.mockProviderRepository.EXPECT().Find(mock.AnythingOfType("*context.emptyCtx")).Return(providers, nil).Once()
-		expectedResources := []*domain.Resource{}
-		for _, p := range providers {
-			resources := []*domain.Resource{
-				{
-					ProviderType: p.Type,
-					ProviderURN:  p.URN,
+		existingResources := []*domain.Resource{
+			{
+				ID:           "1",
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-1",
+				Details: map[string]interface{}{
+					"owner": "test-owner",
+					"_metadata": map[string]interface{}{
+						"labels": map[string]string{
+							"foo": "bar",
+							"baz": "qux",
+						},
+						"x": "y",
+					},
 				},
-			}
-			s.mockProvider.On("GetResources", p.Config).Return(resources, nil).Once()
-			expectedResources = append(expectedResources, resources...)
+			},
 		}
-		s.mockResourceService.On("BulkUpsert", mock.Anything, expectedResources).Return(nil).Once()
-		s.mockResourceService.On("Find", mock.Anything, mock.Anything).Return([]*domain.Resource{}, nil).Once()
+		newResources := []*domain.Resource{
+			{
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-1",
+				Details: map[string]interface{}{
+					"_metadata": map[string]interface{}{
+						"labels": map[string]string{
+							"new-key": "new-value",
+						},
+					},
+				},
+			},
+			{
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-2",
+			},
+		}
+		expectedResources := []*domain.Resource{
+			{
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-1",
+				Details: map[string]interface{}{
+					"owner": "test-owner", // owner not changed
+					"_metadata": map[string]interface{}{ // metadata updated
+						"labels": map[string]string{
+							"new-key": "new-value",
+						},
+					},
+				},
+			},
+			{
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-2",
+			},
+		}
+
+		expectedProvider := providers[0]
+		s.mockProviderRepository.EXPECT().Find(mock.AnythingOfType("*context.emptyCtx")).Return([]*domain.Provider{expectedProvider}, nil).Once()
+		s.mockProvider.EXPECT().GetResources(expectedProvider.Config).Return(newResources, nil).Once()
+		s.mockResourceService.EXPECT().BulkUpsert(mock.Anything, mock.AnythingOfType("[]*domain.Resource")).
+			Run(func(_a0 context.Context, resources []*domain.Resource) {
+				s.Empty(cmp.Diff(expectedResources, resources, cmpopts.IgnoreFields(domain.Resource{}, "ID", "CreatedAt", "UpdatedAt")))
+			}).Return(nil).Once()
+		s.mockResourceService.EXPECT().Find(mock.Anything, mock.Anything).Return(existingResources, nil).Once()
 		actualError := s.service.FetchResources(context.Background())
 
 		s.Nil(actualError)

--- a/core/provider/service_test.go
+++ b/core/provider/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/goto/guardian/core/provider"
 	providermocks "github.com/goto/guardian/core/provider/mocks"
+	"github.com/goto/guardian/core/resource"
 	"github.com/goto/guardian/domain"
 	"github.com/goto/salt/log"
 	"github.com/stretchr/testify/mock"
@@ -360,7 +361,7 @@ func (s *ServiceTestSuite) TestFetchResources() {
 				URN:          "test-resource-urn-1",
 				Details: map[string]interface{}{
 					"owner": "test-owner",
-					"_metadata": map[string]interface{}{
+					resource.ReservedDetailsKeyMetadata: map[string]interface{}{
 						"labels": map[string]string{
 							"foo": "bar",
 							"baz": "qux",
@@ -377,7 +378,7 @@ func (s *ServiceTestSuite) TestFetchResources() {
 				Type:         "test-resource-type",
 				URN:          "test-resource-urn-1",
 				Details: map[string]interface{}{
-					"_metadata": map[string]interface{}{
+					resource.ReservedDetailsKeyMetadata: map[string]interface{}{
 						"labels": map[string]string{
 							"new-key": "new-value",
 						},
@@ -399,7 +400,7 @@ func (s *ServiceTestSuite) TestFetchResources() {
 				URN:          "test-resource-urn-1",
 				Details: map[string]interface{}{
 					"owner": "test-owner", // owner not changed
-					"_metadata": map[string]interface{}{ // metadata updated
+					resource.ReservedDetailsKeyMetadata: map[string]interface{}{ // metadata updated
 						"labels": map[string]string{
 							"new-key": "new-value",
 						},

--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -13,6 +13,8 @@ const (
 	AuditKeyResourceUpdate      = "resource.update"
 	AuditKeyResourceDelete      = "resource.delete"
 	AuditKeyResourceBatchDelete = "resource.batchDelete"
+
+	ReservedDetailsKeyMetadata = "__metadata"
 )
 
 //go:generate mockery --name=repository --exported --with-expecter
@@ -89,9 +91,9 @@ func (s *Service) Update(ctx context.Context, r *domain.Resource) error {
 		return err
 	}
 
-	// Details["_metadata"] is not allowed to be updated by users
+	// Details[ReservedDetailsKeyMetadata] is not allowed to be updated by users
 	// value for this field should only set by the provider on FetchResources
-	delete(r.Details, "_metadata")
+	delete(r.Details, ReservedDetailsKeyMetadata)
 
 	if err := mergo.Merge(r, existingResource); err != nil {
 		return err

--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -89,6 +89,10 @@ func (s *Service) Update(ctx context.Context, r *domain.Resource) error {
 		return err
 	}
 
+	// Details["_metadata"] is not allowed to be updated by users
+	// value for this field should only set by the provider on FetchResources
+	delete(r.Details, "_metadata")
+
 	if err := mergo.Merge(r, existingResource); err != nil {
 		return err
 	}

--- a/core/resource/service_test.go
+++ b/core/resource/service_test.go
@@ -172,12 +172,12 @@ func (s *ServiceTestSuite) TestUpdate() {
 				},
 			},
 			{
-				name: "should exclude _metadata from update payload",
+				name: "should exclude __metadata from update payload",
 				resourceUpdatePayload: &domain.Resource{
 					ID: "2",
 					Details: map[string]interface{}{
 						"owner": "new-owner@example.com",
-						"_metadata": map[string]string{
+						resource.ReservedDetailsKeyMetadata: map[string]string{
 							"new-key": "new-value",
 						},
 					},
@@ -187,7 +187,7 @@ func (s *ServiceTestSuite) TestUpdate() {
 					Details: map[string]interface{}{
 						"owner": "user@example.com",
 						"foo":   "bar",
-						"_metadata": map[string]string{
+						resource.ReservedDetailsKeyMetadata: map[string]string{
 							"key": "value",
 						},
 					},
@@ -197,7 +197,7 @@ func (s *ServiceTestSuite) TestUpdate() {
 					Details: map[string]interface{}{
 						"owner": "new-owner@example.com",
 						"foo":   "bar",
-						"_metadata": map[string]string{
+						resource.ReservedDetailsKeyMetadata: map[string]string{
 							"key": "value",
 						},
 					},

--- a/core/resource/service_test.go
+++ b/core/resource/service_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/goto/guardian/core/resource"
 	"github.com/goto/guardian/core/resource/mocks"
 	"github.com/goto/guardian/domain"
@@ -115,11 +117,13 @@ func (s *ServiceTestSuite) TestUpdate() {
 
 	s.Run("should only allows details and labels to be edited", func() {
 		testCases := []struct {
+			name                  string
 			resourceUpdatePayload *domain.Resource
 			existingResource      *domain.Resource
 			expectedUpdatedValues *domain.Resource
 		}{
 			{
+				name: "empty labels in existing resource",
 				resourceUpdatePayload: &domain.Resource{
 					ID: "1",
 					Labels: map[string]string{
@@ -137,6 +141,7 @@ func (s *ServiceTestSuite) TestUpdate() {
 				},
 			},
 			{
+				name: "empty details in existing resource",
 				resourceUpdatePayload: &domain.Resource{
 					ID: "2",
 					Details: map[string]interface{}{
@@ -154,6 +159,7 @@ func (s *ServiceTestSuite) TestUpdate() {
 				},
 			},
 			{
+				name: "trying to update resource type",
 				resourceUpdatePayload: &domain.Resource{
 					ID:   "2",
 					Type: "test",
@@ -165,17 +171,54 @@ func (s *ServiceTestSuite) TestUpdate() {
 					ID: "2",
 				},
 			},
+			{
+				name: "should exclude _metadata from update payload",
+				resourceUpdatePayload: &domain.Resource{
+					ID: "2",
+					Details: map[string]interface{}{
+						"owner": "new-owner@example.com",
+						"_metadata": map[string]string{
+							"new-key": "new-value",
+						},
+					},
+				},
+				existingResource: &domain.Resource{
+					ID: "2",
+					Details: map[string]interface{}{
+						"owner": "user@example.com",
+						"foo":   "bar",
+						"_metadata": map[string]string{
+							"key": "value",
+						},
+					},
+				},
+				expectedUpdatedValues: &domain.Resource{
+					ID: "2",
+					Details: map[string]interface{}{
+						"owner": "new-owner@example.com",
+						"foo":   "bar",
+						"_metadata": map[string]string{
+							"key": "value",
+						},
+					},
+				},
+			},
 		}
 
 		for _, tc := range testCases {
-			s.mockRepository.EXPECT().GetOne(mock.AnythingOfType("*context.emptyCtx"), tc.resourceUpdatePayload.ID).Return(tc.existingResource, nil).Once()
-			s.mockRepository.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), tc.expectedUpdatedValues).Return(nil).Once()
-			s.mockAuditLogger.EXPECT().Log(mock.Anything, resource.AuditKeyResourceUpdate, mock.Anything).Return(nil)
+			s.Run(tc.name, func() {
+				s.mockRepository.EXPECT().GetOne(mock.AnythingOfType("*context.emptyCtx"), tc.resourceUpdatePayload.ID).Return(tc.existingResource, nil).Once()
+				s.mockRepository.EXPECT().Update(mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*domain.Resource")).
+					Run(func(_a0 context.Context, updateResourcePayload *domain.Resource) {
+						s.Empty(cmp.Diff(tc.expectedUpdatedValues, updateResourcePayload, cmpopts.IgnoreFields(domain.Resource{}, "UpdatedAt", "CreatedAt")))
+					}).Return(nil).Once()
+				s.mockAuditLogger.EXPECT().Log(mock.Anything, resource.AuditKeyResourceUpdate, mock.Anything).Return(nil)
 
-			actualError := s.service.Update(context.Background(), tc.resourceUpdatePayload)
+				actualError := s.service.Update(context.Background(), tc.resourceUpdatePayload)
 
-			s.Nil(actualError)
-			s.mockRepository.AssertExpectations(s.T())
+				s.Nil(actualError)
+				s.mockRepository.AssertExpectations(s.T())
+			})
 		}
 	})
 }

--- a/plugins/providers/bigquery/client.go
+++ b/plugins/providers/bigquery/client.go
@@ -49,30 +49,20 @@ func newBigQueryClient(projectID string, credentialsJSON []byte) (*bigQueryClien
 // GetDatasets returns all datasets within a project
 func (c *bigQueryClient) GetDatasets(ctx context.Context) ([]*Dataset, error) {
 	var results []*Dataset
-	it := c.client.Datasets(ctx)
-	for {
-		dataset, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
 
-		d := &Dataset{
-			ProjectID: dataset.ProjectID,
-			DatasetID: dataset.DatasetID,
+	req := c.apiClient.Datasets.List(c.projectID)
+	if err := req.Pages(ctx, func(page *bqApi.DatasetList) error {
+		for _, dataset := range page.Datasets {
+			d := &Dataset{
+				ProjectID: dataset.DatasetReference.ProjectId,
+				DatasetID: dataset.DatasetReference.DatasetId,
+				Labels:    dataset.Labels,
+			}
+			results = append(results, d)
 		}
-
-		md, err := dataset.Metadata(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("getting metadata for dataset %s: %w", dataset.DatasetID, err)
-		}
-		if md.Labels != nil {
-			d.Labels = md.Labels
-		}
-
-		results = append(results, d)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return results, nil
@@ -81,31 +71,21 @@ func (c *bigQueryClient) GetDatasets(ctx context.Context) ([]*Dataset, error) {
 // GetTables returns all tables within a dataset
 func (c *bigQueryClient) GetTables(ctx context.Context, datasetID string) ([]*Table, error) {
 	var results []*Table
-	it := c.client.Dataset(datasetID).Tables(ctx)
-	for {
-		table, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
 
-		t := &Table{
-			ProjectID: table.ProjectID,
-			DatasetID: table.DatasetID,
-			TableID:   table.TableID,
+	req := c.apiClient.Tables.List(c.projectID, datasetID)
+	if err := req.Pages(ctx, func(page *bqApi.TableList) error {
+		for _, table := range page.Tables {
+			t := &Table{
+				ProjectID: table.TableReference.ProjectId,
+				DatasetID: table.TableReference.DatasetId,
+				TableID:   table.TableReference.TableId,
+				Labels:    table.Labels,
+			}
+			results = append(results, t)
 		}
-
-		md, err := table.Metadata(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("getting metadata for table %s: %w", table.TableID, err)
-		}
-		if md.Labels != nil {
-			t.Labels = md.Labels
-		}
-
-		results = append(results, t)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return results, nil

--- a/plugins/providers/bigquery/client.go
+++ b/plugins/providers/bigquery/client.go
@@ -59,10 +59,20 @@ func (c *bigQueryClient) GetDatasets(ctx context.Context) ([]*Dataset, error) {
 			return nil, err
 		}
 
-		results = append(results, &Dataset{
+		d := &Dataset{
 			ProjectID: dataset.ProjectID,
 			DatasetID: dataset.DatasetID,
-		})
+		}
+
+		md, err := dataset.Metadata(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getting metadata for dataset %s: %w", dataset.DatasetID, err)
+		}
+		if md.Labels != nil {
+			d.Labels = md.Labels
+		}
+
+		results = append(results, d)
 	}
 
 	return results, nil
@@ -81,11 +91,21 @@ func (c *bigQueryClient) GetTables(ctx context.Context, datasetID string) ([]*Ta
 			return nil, err
 		}
 
-		results = append(results, &Table{
+		t := &Table{
 			ProjectID: table.ProjectID,
 			DatasetID: table.DatasetID,
 			TableID:   table.TableID,
-		})
+		}
+
+		md, err := table.Metadata(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getting metadata for table %s: %w", table.TableID, err)
+		}
+		if md.Labels != nil {
+			t.Labels = md.Labels
+		}
+
+		results = append(results, t)
 	}
 
 	return results, nil

--- a/plugins/providers/bigquery/client.go
+++ b/plugins/providers/bigquery/client.go
@@ -21,19 +21,19 @@ type bigQueryClient struct {
 	apiClient  *bqApi.Service
 }
 
-func newBigQueryClient(projectID string, credentialsJSON []byte) (*bigQueryClient, error) {
+func NewBigQueryClient(projectID string, opts ...option.ClientOption) (*bigQueryClient, error) {
 	ctx := context.Background()
-	client, err := bq.NewClient(ctx, projectID, option.WithCredentialsJSON(credentialsJSON))
+	client, err := bq.NewClient(ctx, projectID, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	apiClient, err := bqApi.NewService(ctx, option.WithCredentialsJSON(credentialsJSON))
+	apiClient, err := bqApi.NewService(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	iamService, err := iam.NewService(ctx, option.WithCredentialsJSON(credentialsJSON))
+	iamService, err := iam.NewService(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/providers/bigquery/client_test.go
+++ b/plugins/providers/bigquery/client_test.go
@@ -1,0 +1,155 @@
+package bigquery_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/goto/guardian/plugins/providers/bigquery"
+	"github.com/stretchr/testify/suite"
+	bqApi "google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/option"
+)
+
+type ClientTestSuite struct {
+	suite.Suite
+}
+
+func TestClient(t *testing.T) {
+	suite.Run(t, new(ClientTestSuite))
+}
+
+func (s *ClientTestSuite) TestGetDatasets() {
+	projectID := "test_project"
+	expectedDatasets := []*bigquery.Dataset{
+		{
+			ProjectID: projectID,
+			DatasetID: "dataset_1",
+			Labels: map[string]string{
+				"test_label": "test_value",
+			},
+		},
+		{
+			ProjectID: projectID,
+			DatasetID: "dataset_2",
+		},
+	}
+
+	isFirstPageHelper := true
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := &bqApi.DatasetList{}
+		if isFirstPageHelper {
+			res.NextPageToken = "test_next_page_token"
+			res.Datasets = []*bqApi.DatasetListDatasets{
+				{
+					Id: projectID + ":dataset_1",
+					DatasetReference: &bqApi.DatasetReference{
+						DatasetId: "dataset_1",
+						ProjectId: projectID,
+					},
+					Labels: map[string]string{
+						"test_label": "test_value",
+					},
+				},
+			}
+			isFirstPageHelper = false
+		} else { // 2nd page
+			res.Datasets = []*bqApi.DatasetListDatasets{
+				{
+					Id: projectID + ":dataset_2",
+					DatasetReference: &bqApi.DatasetReference{
+						DatasetId: "dataset_2",
+						ProjectId: projectID,
+					},
+				},
+			}
+		}
+
+		b, err := json.Marshal(res)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Write(b)
+	}))
+	defer ts.Close()
+
+	client, err := bigquery.NewBigQueryClient(projectID, option.WithoutAuthentication(), option.WithEndpoint(ts.URL))
+	s.Require().NoError(err)
+
+	datasets, err := client.GetDatasets(context.Background())
+
+	s.Nil(err)
+	s.Equal(expectedDatasets, datasets)
+}
+
+func (s *ClientTestSuite) TestGetTables() {
+	projectID := "test_project"
+	datasetID := "test_dataset"
+	expectedTables := []*bigquery.Table{
+		{
+			ProjectID: projectID,
+			DatasetID: datasetID,
+			TableID:   "table_1",
+			Labels: map[string]string{
+				"test_label": "test_value",
+			},
+		},
+		{
+			ProjectID: projectID,
+			DatasetID: datasetID,
+			TableID:   "table_2",
+		},
+	}
+
+	isFirstPageHelper := true
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := &bqApi.TableList{}
+		if isFirstPageHelper {
+			res.NextPageToken = "test_next_page_token"
+			res.Tables = []*bqApi.TableListTables{
+				{
+					Id: projectID + ":" + datasetID + ".table_1",
+					TableReference: &bqApi.TableReference{
+						ProjectId: projectID,
+						DatasetId: datasetID,
+						TableId:   "table_1",
+					},
+					Labels: map[string]string{
+						"test_label": "test_value",
+					},
+				},
+			}
+			isFirstPageHelper = false
+		} else { // 2nd page
+			res.Tables = []*bqApi.TableListTables{
+				{
+					Id: projectID + ":" + datasetID + ".table_2",
+					TableReference: &bqApi.TableReference{
+						ProjectId: projectID,
+						DatasetId: datasetID,
+						TableId:   "table_2",
+					},
+				},
+			}
+		}
+
+		b, err := json.Marshal(res)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Write(b)
+	}))
+	defer ts.Close()
+
+	client, err := bigquery.NewBigQueryClient(projectID, option.WithoutAuthentication(), option.WithEndpoint(ts.URL))
+	s.Require().NoError(err)
+
+	tables, err := client.GetTables(context.Background(), datasetID)
+
+	s.Nil(err)
+	s.Equal(expectedTables, tables)
+}

--- a/plugins/providers/bigquery/config.go
+++ b/plugins/providers/bigquery/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goto/guardian/domain"
 	"github.com/goto/guardian/utils"
 	"github.com/mitchellh/mapstructure"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -132,7 +133,7 @@ func (c *Config) parseAndValidate() error {
 	}
 
 	projectID := strings.Replace(credentials.ResourceName, "projects/", "", 1)
-	client, err := newBigQueryClient(projectID, []byte(credentials.ServiceAccountKey))
+	client, err := NewBigQueryClient(projectID, option.WithCredentialsJSON([]byte(credentials.ServiceAccountKey)))
 	if err != nil {
 		return err
 	}

--- a/plugins/providers/bigquery/model.go
+++ b/plugins/providers/bigquery/model.go
@@ -39,17 +39,13 @@ func (d *Dataset) ToDomain() *domain.Resource {
 		URN:  fmt.Sprintf("%s:%s", d.ProjectID, d.DatasetID),
 	}
 
-	var metadata map[string]interface{}
 	if d.Labels != nil {
-		metadata = map[string]interface{}{
-			"labels": d.Labels,
-		}
-	}
-	if metadata != nil {
 		if r.Details == nil {
 			r.Details = make(map[string]interface{})
 		}
-		r.Details["_metadata"] = metadata
+		r.Details["_metadata"] = map[string]interface{}{
+			"labels": d.Labels,
+		}
 	}
 
 	return r
@@ -85,17 +81,13 @@ func (t *Table) ToDomain() *domain.Resource {
 		URN:  fmt.Sprintf("%s:%s.%s", t.ProjectID, t.DatasetID, t.TableID),
 	}
 
-	var metadata map[string]interface{}
 	if t.Labels != nil {
-		metadata = map[string]interface{}{
-			"labels": t.Labels,
-		}
-	}
-	if metadata != nil {
 		if r.Details == nil {
 			r.Details = make(map[string]interface{})
 		}
-		r.Details["_metadata"] = metadata
+		r.Details["_metadata"] = map[string]interface{}{
+			"labels": t.Labels,
+		}
 	}
 
 	return r

--- a/plugins/providers/bigquery/model.go
+++ b/plugins/providers/bigquery/model.go
@@ -19,6 +19,7 @@ const (
 type Dataset struct {
 	ProjectID string
 	DatasetID string
+	Labels    map[string]string
 }
 
 func (d *Dataset) FromDomain(r *domain.Resource) error {
@@ -32,11 +33,26 @@ func (d *Dataset) FromDomain(r *domain.Resource) error {
 }
 
 func (d *Dataset) ToDomain() *domain.Resource {
-	return &domain.Resource{
+	r := &domain.Resource{
 		Type: ResourceTypeDataset,
 		Name: d.DatasetID,
 		URN:  fmt.Sprintf("%s:%s", d.ProjectID, d.DatasetID),
 	}
+
+	var metadata map[string]interface{}
+	if d.Labels != nil {
+		metadata = map[string]interface{}{
+			"labels": d.Labels,
+		}
+	}
+	if metadata != nil {
+		if r.Details == nil {
+			r.Details = make(map[string]interface{})
+		}
+		r.Details["_metadata"] = metadata
+	}
+
+	return r
 }
 
 // Table is a reference to a BigQuery table
@@ -44,6 +60,7 @@ type Table struct {
 	ProjectID string
 	DatasetID string
 	TableID   string
+	Labels    map[string]string
 }
 
 func (t *Table) FromDomain(r *domain.Resource) error {
@@ -62,11 +79,26 @@ func (t *Table) FromDomain(r *domain.Resource) error {
 }
 
 func (t *Table) ToDomain() *domain.Resource {
-	return &domain.Resource{
+	r := &domain.Resource{
 		Type: ResourceTypeTable,
 		Name: t.TableID,
 		URN:  fmt.Sprintf("%s:%s.%s", t.ProjectID, t.DatasetID, t.TableID),
 	}
+
+	var metadata map[string]interface{}
+	if t.Labels != nil {
+		metadata = map[string]interface{}{
+			"labels": t.Labels,
+		}
+	}
+	if metadata != nil {
+		if r.Details == nil {
+			r.Details = make(map[string]interface{})
+		}
+		r.Details["_metadata"] = metadata
+	}
+
+	return r
 }
 
 type datasetAccessEntry bq.AccessEntry

--- a/plugins/providers/bigquery/model.go
+++ b/plugins/providers/bigquery/model.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	bq "cloud.google.com/go/bigquery"
+	"github.com/goto/guardian/core/resource"
 	"github.com/goto/guardian/domain"
 )
 
@@ -43,7 +44,7 @@ func (d *Dataset) ToDomain() *domain.Resource {
 		if r.Details == nil {
 			r.Details = make(map[string]interface{})
 		}
-		r.Details["_metadata"] = map[string]interface{}{
+		r.Details[resource.ReservedDetailsKeyMetadata] = map[string]interface{}{
 			"labels": d.Labels,
 		}
 	}
@@ -85,7 +86,7 @@ func (t *Table) ToDomain() *domain.Resource {
 		if r.Details == nil {
 			r.Details = make(map[string]interface{})
 		}
-		r.Details["_metadata"] = map[string]interface{}{
+		r.Details[resource.ReservedDetailsKeyMetadata] = map[string]interface{}{
 			"labels": t.Labels,
 		}
 	}

--- a/plugins/providers/bigquery/provider.go
+++ b/plugins/providers/bigquery/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/patrickmn/go-cache"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/option"
 )
 
 var (
@@ -342,7 +343,7 @@ func (p *Provider) getBigQueryClient(credentials Credentials) (BigQueryClient, e
 	}
 
 	credentials.Decrypt(p.encryptor)
-	client, err := newBigQueryClient(projectID, []byte(credentials.ServiceAccountKey))
+	client, err := NewBigQueryClient(projectID, option.WithCredentialsJSON([]byte(credentials.ServiceAccountKey)))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/providers/bigquery/provider.go
+++ b/plugins/providers/bigquery/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goto/salt/log"
 	"github.com/mitchellh/mapstructure"
 	"github.com/patrickmn/go-cache"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -120,32 +121,40 @@ func (p *Provider) GetResources(pc *domain.ProviderConfig) ([]*domain.Resource, 
 	resourceTypes := pc.GetResourceTypes()
 
 	resources := []*domain.Resource{}
-	ctx := context.Background()
+	eg, ctx := errgroup.WithContext(context.TODO())
+
 	datasets, err := client.GetDatasets(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for _, d := range datasets {
-		dataset := d.ToDomain()
-		dataset.ProviderType = pc.Type
-		dataset.ProviderURN = pc.URN
+		d := d
+		eg.Go(func() error {
+			dataset := d.ToDomain()
+			dataset.ProviderType = pc.Type
+			dataset.ProviderURN = pc.URN
 
-		if containsString(resourceTypes, ResourceTypeDataset) {
-			resources = append(resources, dataset)
-		}
+			if containsString(resourceTypes, ResourceTypeDataset) {
+				resources = append(resources, dataset)
+			}
 
-		if containsString(resourceTypes, ResourceTypeTable) {
-			tables, err := client.GetTables(ctx, dataset.Name)
-			if err != nil {
-				return nil, err
+			if containsString(resourceTypes, ResourceTypeTable) {
+				tables, err := client.GetTables(ctx, dataset.Name)
+				if err != nil {
+					return fmt.Errorf("fetching tables for dataset %q: %w", dataset.URN, err)
+				}
+				for _, t := range tables {
+					table := t.ToDomain()
+					table.ProviderType = pc.Type
+					table.ProviderURN = pc.URN
+					dataset.Children = append(dataset.Children, table)
+				}
 			}
-			for _, t := range tables {
-				table := t.ToDomain()
-				table.ProviderType = pc.Type
-				table.ProviderURN = pc.URN
-				dataset.Children = append(dataset.Children, table)
-			}
-		}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 
 	return resources, nil

--- a/plugins/providers/bigquery/provider.go
+++ b/plugins/providers/bigquery/provider.go
@@ -123,6 +123,7 @@ func (p *Provider) GetResources(pc *domain.ProviderConfig) ([]*domain.Resource, 
 
 	resources := []*domain.Resource{}
 	eg, ctx := errgroup.WithContext(context.TODO())
+	eg.SetLimit(10)
 
 	datasets, err := client.GetDatasets(ctx)
 	if err != nil {


### PR DESCRIPTION
related discussion: https://github.com/odpf/guardian/issues/372

Changes:
1. include labels from dataset & table when fetching resources
2. prevent `Resource.Details["_metadata"]` update from users in `UpdateResource`