### PR TITLE
fix: send proper error code in case of bad request

### DIFF
--- a/api/handler/v1beta1/appeal_test.go
+++ b/api/handler/v1beta1/appeal_test.go
@@ -3,6 +3,7 @@ package v1beta1_test
 import (
 	"context"
 	"errors"
+	"github.com/google/uuid"
 	"time"
 
 	guardianv1beta1 "github.com/goto/guardian/api/proto/gotocompany/guardian/v1beta1"
@@ -557,7 +558,7 @@ func (s *GrpcHandlersSuite) TestGetAppeal() {
 		s.setup()
 		timeNow := time.Now()
 
-		expectedID := "test-appeal-id"
+		expectedID := uuid.New().String()
 		expectedAppeal := &domain.Appeal{
 			ID:         expectedID,
 			ResourceID: "test-resource-id",
@@ -655,7 +656,9 @@ func (s *GrpcHandlersSuite) TestGetAppeal() {
 		s.appealService.EXPECT().GetByID(mock.AnythingOfType("*context.emptyCtx"), mock.Anything).
 			Return(nil, expectedError).Once()
 
-		req := &guardianv1beta1.GetAppealRequest{}
+		req := &guardianv1beta1.GetAppealRequest{
+			Id: uuid.New().String(),
+		}
 		res, err := s.grpcServer.GetAppeal(context.Background(), req)
 
 		s.Equal(codes.Internal, status.Code(err))
@@ -669,7 +672,9 @@ func (s *GrpcHandlersSuite) TestGetAppeal() {
 		s.appealService.EXPECT().GetByID(mock.AnythingOfType("*context.emptyCtx"), mock.Anything).
 			Return(nil, nil).Once()
 
-		req := &guardianv1beta1.GetAppealRequest{}
+		req := &guardianv1beta1.GetAppealRequest{
+			Id: uuid.New().String(),
+		}
 		res, err := s.grpcServer.GetAppeal(context.Background(), req)
 
 		s.Equal(codes.NotFound, status.Code(err))
@@ -688,13 +693,16 @@ func (s *GrpcHandlersSuite) TestGetAppeal() {
 		s.appealService.EXPECT().GetByID(mock.AnythingOfType("*context.emptyCtx"), mock.Anything).
 			Return(invalidAppeal, nil).Once()
 
-		req := &guardianv1beta1.GetAppealRequest{}
+		req := &guardianv1beta1.GetAppealRequest{
+			Id: uuid.New().String(),
+		}
 		res, err := s.grpcServer.GetAppeal(context.Background(), req)
 
 		s.Equal(codes.Internal, status.Code(err))
 		s.Nil(res)
 		s.appealService.AssertExpectations(s.T())
 	})
+
 }
 
 func (s *GrpcHandlersSuite) TestCancelAppeal() {
@@ -702,7 +710,7 @@ func (s *GrpcHandlersSuite) TestCancelAppeal() {
 		s.setup()
 		timeNow := time.Now()
 
-		expectedID := "test-appeal-id"
+		expectedID := uuid.New().String()
 		expectedAppeal := &domain.Appeal{
 			ID:         expectedID,
 			ResourceID: "test-resource-id",
@@ -838,7 +846,9 @@ func (s *GrpcHandlersSuite) TestCancelAppeal() {
 				s.appealService.EXPECT().Cancel(mock.AnythingOfType("*context.emptyCtx"), mock.Anything).
 					Return(nil, tc.expectedError).Once()
 
-				req := &guardianv1beta1.CancelAppealRequest{}
+				req := &guardianv1beta1.CancelAppealRequest{
+					Id: uuid.New().String(),
+				}
 				res, err := s.grpcServer.CancelAppeal(context.Background(), req)
 
 				s.Equal(tc.expectedStatusCode, status.Code(err))
@@ -859,7 +869,9 @@ func (s *GrpcHandlersSuite) TestCancelAppeal() {
 		s.appealService.EXPECT().Cancel(mock.AnythingOfType("*context.emptyCtx"), mock.Anything).
 			Return(invalidAppeal, nil).Once()
 
-		req := &guardianv1beta1.CancelAppealRequest{}
+		req := &guardianv1beta1.CancelAppealRequest{
+			Id: uuid.New().String(),
+		}
 		res, err := s.grpcServer.CancelAppeal(context.Background(), req)
 
 		s.Equal(codes.Internal, status.Code(err))

--- a/core/appeal/errors.go
+++ b/core/appeal/errors.go
@@ -1,6 +1,9 @@
 package appeal
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	ErrAppealIDEmptyParam   = errors.New("appeal id is required")
@@ -50,3 +53,11 @@ var (
 	ErrApproverNotFound         = errors.New("approver not found")
 	ErrGrantNotFound            = errors.New("grant not found")
 )
+
+type InvalidError struct {
+	AppealID string
+}
+
+func (ie InvalidError) Error() string {
+	return fmt.Sprintf("invalid appeal id: %s", ie.AppealID)
+}

--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -159,6 +159,10 @@ func (s *Service) GetByID(ctx context.Context, id string) (*domain.Appeal, error
 		return nil, ErrAppealIDEmptyParam
 	}
 
+	if !utils.IsValidUUID(id) {
+		return nil, InvalidError{AppealID: id}
+	}
+
 	return s.repo.GetByID(ctx, id)
 }
 
@@ -590,6 +594,14 @@ func (s *Service) Update(ctx context.Context, appeal *domain.Appeal) error {
 }
 
 func (s *Service) Cancel(ctx context.Context, id string) (*domain.Appeal, error) {
+	if id == "" {
+		return nil, ErrAppealIDEmptyParam
+	}
+
+	if !utils.IsValidUUID(id) {
+		return nil, InvalidError{AppealID: id}
+	}
+
 	appeal, err := s.GetByID(ctx, id)
 	if err != nil {
 		return nil, err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,5 +1,7 @@
 package utils
 
+import "github.com/google/uuid"
+
 func IsInteger(val float64) bool {
 	return val == float64(int(val))
 }
@@ -18,4 +20,10 @@ func MapToSlice(m map[string]string) []string {
 		i++
 	}
 	return s
+}
+
+// IsValidUUID returns true if uuid is valid
+func IsValidUUID(u string) bool {
+	_, err := uuid.Parse(u)
+	return err == nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -48,3 +48,86 @@ func TestMapToSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidUUID(t *testing.T) {
+	type args struct {
+		u string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid uuid",
+			args: args{
+				u: "123e4567-e89b-12d3-a456-426614174000",
+			},
+			want: true,
+		},
+		{
+			name: "invalid uuid",
+			args: args{
+				u: "123e4567-a456-42661417400",
+			},
+			want: false,
+		},
+		{
+			name: "empty uuid",
+			args: args{
+				u: "",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, IsValidUUID(tt.args.u), "IsValidUUID(%v)", tt.args.u)
+		})
+	}
+}
+
+func TestIsInteger(t *testing.T) {
+	type args struct {
+		val float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "is integer",
+			args: args{
+				val: 1,
+			},
+			want: true,
+		},
+		{
+			name: "is not integer",
+			args: args{
+				val: 1.1,
+			},
+			want: false,
+		},
+		{
+			name: "is not integer",
+			args: args{
+				val: 0.1,
+			},
+			want: false,
+		},
+		{
+			name: "is integer",
+			args: args{
+				val: 0.0,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, IsInteger(tt.args.val), "IsInteger(%v)", tt.args.val)
+		})
+	}
+}


### PR DESCRIPTION
- If the id is empty or invalid in request, server should return 400 bad request instead of 500 internal server error

fixes: #37 