### PR TITLE
fix: fix goreleaser action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2.6.1
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.18.2
           args: --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2.6.1
         with:
           distribution: goreleaser
-          version: v1.18.2
+          version: latest
           args: --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,12 +20,16 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-  - replacements:
-      darwin: macos
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else if eq .Arch "linux" }}linux
+      {{- else if eq .Arch "windows" }}windows
+      {{- else if eq .Arch "darwin" }}macos
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip
@@ -58,8 +62,10 @@ nfpms:
     formats:
       - deb
       - rpm
-    replacements:
-      darwin: macOS
+    file_name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "darwin" }}macos{{- else }}{{ .Arch }}{{ end }}
 scoop:
   bucket:
     owner: goto


### PR DESCRIPTION
`replacements` field has been removed in goreleaser `v1.19.0` which causes an error in our release pipeline because we configured to use `latest` version

sample error: https://github.com/goto/guardian/actions/runs/5851925012/job/15869183342