### PR TITLE
fix: bug in appeal creation

### DIFF
--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -276,7 +276,7 @@ func (s *Service) Create(ctx context.Context, appeals []*domain.Appeal, opts ...
 		appeal.Policy = nil
 
 		for _, approval := range appeal.Approvals {
-			if approval.Index == len(appeal.Approvals)-1 && approval.Status == domain.ApprovalStatusApproved {
+			if approval.Index == len(appeal.Approvals)-1 && (approval.Status == domain.ApprovalStatusApproved || appeal.Status == domain.AppealStatusApproved) {
 				newGrant, revokedGrant, err := s.prepareGrant(ctx, appeal)
 				if err != nil {
 					return fmt.Errorf("preparing grant: %w", err)


### PR DESCRIPTION
- bug: if a policy only has auto approval steps, and the appeal gets auto-approved with last approval step as skipped, then with the current logic the appeal is approved but the grant never gets created. Fix this by adding a check

Closes #75 