### PR TITLE
 build: use updated validate plugin 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ proto:
 
 setup:
 	@echo "Installing dependencies..."
-	go mod tidy
+	go mod download
 	go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
 	go get github.com/golang/protobuf/proto@v1.5.2
 	go get github.com/golang/protobuf/protoc-gen-go@v1.5.2

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -5,15 +5,15 @@ plugins:
     opt: paths=source_relative
   - plugin: buf.build/grpc/go:v1.2.0
     out: api/proto
-    opt: paths=source_relative, require_unimplemented_servers=true 
+    opt:
+      - paths=source_relative
+      - require_unimplemented_servers=true
   - plugin: buf.build/grpc-ecosystem/gateway:v2.15.1
     out: api/proto
     opt: paths=source_relative
   - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.1
     out: third_party/OpenAPI
-#  See https://github.com/bufbuild/protoc-gen-validate/issues/523
-  - remote: buf.build/jirkad/plugins/protoc-gen-validate:v0.6.7
+  - plugin: buf.build/bufbuild/validate-go:v1.0.2
     out: api/proto
     opt:
       - paths=source_relative
-      - lang=go


### PR DESCRIPTION



```text
(⎈|minikube)➜  guardian git:(fix-buf-generate) cat buf.gen.yaml 
version: v1
plugins:
  - plugin: buf.build/protocolbuffers/go:v1.28.1
    out: api/proto
    opt: paths=source_relative
  - plugin: buf.build/grpc/go:v1.2.0
    out: api/proto
    opt:
      - paths=source_relative
      - require_unimplemented_servers=true
  - plugin: buf.build/grpc-ecosystem/gateway:v2.15.1
    out: api/proto
    opt: paths=source_relative
  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.15.1
    out: third_party/OpenAPI
  - plugin: buf.build/bufbuild/validate-go:v1.0.2
    out: api/proto
    opt:
      - paths=source_relative
(⎈|minikube)➜  guardian git:(fix-buf-generate) buf --version
1.26.1
(⎈|minikube)➜  guardian git:(fix-buf-generate) make proto
Generating protobuf from goto/proton
 [info] make sure correct version of dependencies are installed using 'make install'
Protobuf compilation finished
(⎈|minikube)➜  guardian git:(fix-buf-generate)
```

