### PR TITLE
fix(policy): skip validate approver in case expression has appeal.resource

### DIFF
--- a/core/policy/service.go
+++ b/core/policy/service.go
@@ -318,7 +318,7 @@ func (s *Service) validateApprover(expr string) error {
 	}
 
 	// skip validation if expression is accessing arbitrary value
-	if strings.Contains(expr, "$appeal.resource.details") ||
+	if strings.Contains(expr, "$appeal.resource") ||
 		strings.Contains(expr, "$appeal.creator") {
 		return nil
 	}


### PR DESCRIPTION
skipped validate approver in case expression has appeal.resource