### PR TITLE
fix(policy): skip validate approver for arbitrary appeal values

### DIFF
--- a/core/policy/service.go
+++ b/core/policy/service.go
@@ -319,7 +319,11 @@ func (s *Service) validateApprover(expr string) error {
 
 	// skip validation if expression is accessing arbitrary value
 	if strings.Contains(expr, "$appeal.resource") ||
-		strings.Contains(expr, "$appeal.creator") {
+		strings.Contains(expr, "$appeal.creator") ||
+		strings.Contains(expr, "$appeal.role") ||
+		strings.Contains(expr, "$appeal.permissions") ||
+		strings.Contains(expr, "$appeal.details") ||
+		strings.Contains(expr, "$appeal.labels") {
 		return nil
 	}
 

--- a/core/policy/service.go
+++ b/core/policy/service.go
@@ -317,7 +317,8 @@ func (s *Service) validateApprover(expr string) error {
 		return nil
 	}
 
-	// skip validation if expression is accessing arbitrary value
+	// skip validate approver step in case the expression uses arbitrary appeal values
+	// which are only available at the time of appeal creation.
 	if strings.Contains(expr, "$appeal.resource") ||
 		strings.Contains(expr, "$appeal.creator") ||
 		strings.Contains(expr, "$appeal.role") ||


### PR DESCRIPTION
skip validate approver step in case the expression uses arbitrary appeal values which are only available at the time of appeal creation.
