### PR TITLE
feat(log): sending audit log concurrently

### DIFF
--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -376,9 +376,11 @@ func (s *Service) Create(ctx context.Context, appeals []*domain.Appeal, opts ...
 		return fmt.Errorf("inserting appeals into db: %w", err)
 	}
 
-	if err := s.auditLogger.Log(ctx, AuditKeyBulkInsert, appeals); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyBulkInsert, appeals); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	for _, a := range appeals {
 		if a.Status == domain.AppealStatusRejected {
@@ -647,9 +649,11 @@ func (s *Service) UpdateApproval(ctx context.Context, approvalAction domain.Appr
 			auditKey = AuditKeyApprove
 		}
 		if auditKey != "" {
-			if err := s.auditLogger.Log(ctx, auditKey, approvalAction); err != nil {
-				s.logger.Error(ctx, "failed to record audit log", "error", err)
-			}
+			go func() {
+				if err := s.auditLogger.Log(ctx, auditKey, approvalAction); err != nil {
+					s.logger.Error(ctx, "failed to record audit log", "error", err)
+				}
+			}()
 		}
 
 		return appeal, nil
@@ -687,11 +691,13 @@ func (s *Service) Cancel(ctx context.Context, id string) (*domain.Appeal, error)
 		return nil, err
 	}
 
-	if err := s.auditLogger.Log(ctx, AuditKeyCancel, map[string]interface{}{
-		"appeal_id": id,
-	}); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyCancel, map[string]interface{}{
+			"appeal_id": id,
+		}); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	return appeal, nil
 }
@@ -738,9 +744,11 @@ func (s *Service) AddApprover(ctx context.Context, appealID, approvalID, email s
 		return nil, fmt.Errorf("converting approval to map: %w", err)
 	}
 	auditData["affected_approver"] = email
-	if err := s.auditLogger.Log(ctx, AuditKeyAddApprover, auditData); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyAddApprover, auditData); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	duration := domain.PermanentDurationLabel
 	if !appeal.IsDurationEmpty() {
@@ -836,9 +844,11 @@ func (s *Service) DeleteApprover(ctx context.Context, appealID, approvalID, emai
 		return nil, fmt.Errorf("converting approval to map: %w", err)
 	}
 	auditData["affected_approver"] = email
-	if err := s.auditLogger.Log(ctx, AuditKeyDeleteApprover, auditData); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyDeleteApprover, auditData); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	return appeal, nil
 }

--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -749,7 +749,7 @@ func (s *Service) AddApprover(ctx context.Context, appealID, approvalID, email s
 	auditData["affected_approver"] = email
 	go func() {
 		ctx := context.WithoutCancel(ctx)
-		if err := s.auditLogger.Log(ctx, AuditKeyAddApprover, approval); err != nil {
+		if err := s.auditLogger.Log(ctx, AuditKeyAddApprover, auditData); err != nil {
 			s.logger.Error(ctx, "failed to record audit log", "error", err)
 		}
 	}()
@@ -850,7 +850,7 @@ func (s *Service) DeleteApprover(ctx context.Context, appealID, approvalID, emai
 	auditData["affected_approver"] = email
 	go func() {
 		ctx := context.WithoutCancel(ctx)
-		if err := s.auditLogger.Log(ctx, AuditKeyDeleteApprover, approval); err != nil {
+		if err := s.auditLogger.Log(ctx, AuditKeyDeleteApprover, auditData); err != nil {
 			s.logger.Error(ctx, "failed to record audit log", "error", err)
 		}
 	}()

--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -377,6 +377,7 @@ func (s *Service) Create(ctx context.Context, appeals []*domain.Appeal, opts ...
 	}
 
 	go func() {
+		ctx := context.WithoutCancel(ctx)
 		if err := s.auditLogger.Log(ctx, AuditKeyBulkInsert, appeals); err != nil {
 			s.logger.Error(ctx, "failed to record audit log", "error", err)
 		}
@@ -650,6 +651,7 @@ func (s *Service) UpdateApproval(ctx context.Context, approvalAction domain.Appr
 		}
 		if auditKey != "" {
 			go func() {
+				ctx := context.WithoutCancel(ctx)
 				if err := s.auditLogger.Log(ctx, auditKey, approvalAction); err != nil {
 					s.logger.Error(ctx, "failed to record audit log", "error", err)
 				}
@@ -692,6 +694,7 @@ func (s *Service) Cancel(ctx context.Context, id string) (*domain.Appeal, error)
 	}
 
 	go func() {
+		ctx := context.WithoutCancel(ctx)
 		if err := s.auditLogger.Log(ctx, AuditKeyCancel, map[string]interface{}{
 			"appeal_id": id,
 		}); err != nil {
@@ -745,7 +748,8 @@ func (s *Service) AddApprover(ctx context.Context, appealID, approvalID, email s
 	}
 	auditData["affected_approver"] = email
 	go func() {
-		if err := s.auditLogger.Log(ctx, AuditKeyAddApprover, auditData); err != nil {
+		ctx := context.WithoutCancel(ctx)
+		if err := s.auditLogger.Log(ctx, AuditKeyAddApprover, approval); err != nil {
 			s.logger.Error(ctx, "failed to record audit log", "error", err)
 		}
 	}()
@@ -845,7 +849,8 @@ func (s *Service) DeleteApprover(ctx context.Context, appealID, approvalID, emai
 	}
 	auditData["affected_approver"] = email
 	go func() {
-		if err := s.auditLogger.Log(ctx, AuditKeyDeleteApprover, auditData); err != nil {
+		ctx := context.WithoutCancel(ctx)
+		if err := s.auditLogger.Log(ctx, AuditKeyDeleteApprover, approval); err != nil {
 			s.logger.Error(ctx, "failed to record audit log", "error", err)
 		}
 	}()

--- a/core/appeal/service_test.go
+++ b/core/appeal/service_test.go
@@ -1099,9 +1099,10 @@ func (s *ServiceTestSuite) TestCreate() {
 		h.mockNotifier.EXPECT().
 			Notify(h.ctxMatcher, mock.Anything).Return(nil).Once()
 		h.mockAuditLogger.EXPECT().
-			Log(mock.Anything, appeal.AuditKeyBulkInsert, mock.Anything).Return(nil).Once()
+			Log(h.ctxMatcher, appeal.AuditKeyBulkInsert, mock.Anything).Return(nil).Once()
 
 		actualError := h.service.Create(context.Background(), appeals)
+		time.Sleep(time.Millisecond)
 
 		s.Nil(actualError)
 		s.Equal(expectedResult, appeals)
@@ -1564,10 +1565,11 @@ func (s *ServiceTestSuite) TestCreate() {
 		h.mockNotifier.EXPECT().
 			Notify(h.ctxMatcher, mock.Anything).Return(nil).Once()
 		h.mockAuditLogger.EXPECT().
-			Log(mock.Anything, appeal.AuditKeyBulkInsert, mock.Anything).
+			Log(h.ctxMatcher, appeal.AuditKeyBulkInsert, mock.Anything).
 			Return(nil).Once()
 
 		actualError := h.service.Create(context.Background(), appeals)
+		time.Sleep(time.Millisecond)
 
 		s.Nil(actualError)
 		s.Equal(expectedResult, appeals)
@@ -1657,7 +1659,7 @@ func (s *ServiceTestSuite) TestCreate() {
 				BulkUpsert(h.ctxMatcher, mock.Anything).
 				Return(nil).Once()
 			h.mockNotifier.EXPECT().Notify(h.ctxMatcher, mock.Anything).Return(nil).Once()
-			h.mockAuditLogger.EXPECT().Log(mock.Anything, appeal.AuditKeyBulkInsert, mock.Anything).Return(nil).Once()
+			h.mockAuditLogger.EXPECT().Log(h.ctxMatcher, appeal.AuditKeyBulkInsert, mock.Anything).Return(nil).Once()
 			h.mockProviderService.EXPECT().
 				IsExclusiveRoleAssignment(mock.Anything, mock.Anything, mock.Anything).
 				Return(false).Once()
@@ -1667,6 +1669,7 @@ func (s *ServiceTestSuite) TestCreate() {
 			h.mockProviderService.EXPECT().GrantAccess(mock.Anything, mock.Anything).Return(nil).Once()
 
 			err := h.service.Create(context.Background(), []*domain.Appeal{input}, appeal.CreateWithAdditionalAppeal())
+			time.Sleep(time.Millisecond)
 
 			s.NoError(err)
 			s.Equal("test-approval", input.Approvals[0].Name)
@@ -1942,9 +1945,10 @@ func (s *ServiceTestSuite) TestCreateAppeal__WithExistingAppealAndWithAutoApprov
 			}
 		}).Once()
 	h.mockNotifier.EXPECT().Notify(h.ctxMatcher, mock.Anything).Return(nil).Once()
-	h.mockAuditLogger.EXPECT().Log(mock.Anything, appeal.AuditKeyBulkInsert, mock.Anything).Return(nil).Once()
+	h.mockAuditLogger.EXPECT().Log(h.ctxMatcher, appeal.AuditKeyBulkInsert, mock.Anything).Return(nil).Once()
 
 	actualError := h.service.Create(context.Background(), appeals)
+	time.Sleep(time.Millisecond)
 
 	s.Nil(actualError)
 	s.Equal(expectedResult, appeals)
@@ -2126,7 +2130,7 @@ func (s *ServiceTestSuite) TestCreateAppeal__WithAdditionalAppeals() {
 		appeal := appeals[0]
 		s.Equal(targetResource.ID, appeal.Resource.ID)
 	})
-	h.mockAuditLogger.EXPECT().Log(mock.AnythingOfType("*context.cancelCtx"), appeal.AuditKeyBulkInsert, mock.Anything).Return(nil).Once()
+	h.mockAuditLogger.EXPECT().Log(h.ctxMatcher, appeal.AuditKeyBulkInsert, mock.Anything).Return(nil).Once()
 	h.mockNotifier.EXPECT().Notify(h.ctxMatcher, mock.Anything).Return(nil).Once()
 
 	// 1.b grant access for the main appeal
@@ -2143,6 +2147,7 @@ func (s *ServiceTestSuite) TestCreateAppeal__WithAdditionalAppeals() {
 	h.mockNotifier.EXPECT().Notify(h.ctxMatcher, mock.Anything).Return(nil).Once()
 
 	err := h.service.Create(context.Background(), appealsPayload)
+	time.Sleep(time.Millisecond)
 
 	s.NoError(err)
 
@@ -2775,10 +2780,11 @@ func (s *ServiceTestSuite) TestUpdateApproval() {
 		h.mockProviderService.EXPECT().GrantAccess(mock.Anything, mock.Anything).Return(nil).Once()
 		h.mockRepository.EXPECT().Update(h.ctxMatcher, appealDetails).Return(nil).Once()
 		h.mockNotifier.EXPECT().Notify(h.ctxMatcher, mock.Anything).Return(nil).Once()
-		h.mockAuditLogger.EXPECT().Log(mock.Anything, mock.Anything, mock.Anything).
+		h.mockAuditLogger.EXPECT().Log(h.ctxMatcher, mock.Anything, mock.Anything).
 			Return(nil).Once()
 
 		_, actualError := h.service.UpdateApproval(context.Background(), action)
+		time.Sleep(time.Millisecond)
 
 		s.Nil(actualError)
 
@@ -3178,7 +3184,7 @@ func (s *ServiceTestSuite) TestUpdateApproval() {
 
 				h.mockRepository.EXPECT().Update(h.ctxMatcher, tc.expectedResult).Return(nil).Once()
 				h.mockNotifier.EXPECT().Notify(h.ctxMatcher, mock.Anything).Return(nil).Once()
-				h.mockAuditLogger.EXPECT().Log(mock.Anything, mock.Anything, mock.Anything).
+				h.mockAuditLogger.EXPECT().Log(h.ctxMatcher, mock.Anything, mock.Anything).
 					Return(nil).Once()
 
 				actualResult, actualError := h.service.UpdateApproval(context.Background(), tc.expectedApprovalAction)
@@ -3389,6 +3395,7 @@ func (s *ServiceTestSuite) TestAddApprover() {
 					Return(nil).Once()
 
 				actualAppeal, actualError := h.service.AddApprover(context.Background(), appealID, approvalID, newApprover)
+				time.Sleep(time.Millisecond)
 
 				s.NoError(actualError)
 				s.Equal(expectedApproval, actualAppeal.Approvals[0])
@@ -3670,6 +3677,7 @@ func (s *ServiceTestSuite) TestDeleteApprover() {
 					})).Return(nil).Once()
 
 				actualAppeal, actualError := h.service.DeleteApprover(context.Background(), appealID, approvalID, approverEmail)
+				time.Sleep(time.Millisecond)
 
 				s.NoError(actualError)
 				s.Equal(expectedApproval, actualAppeal.Approvals[0])

--- a/core/appeal/service_test.go
+++ b/core/appeal/service_test.go
@@ -1569,7 +1569,6 @@ func (s *ServiceTestSuite) TestCreate() {
 			Return(nil).Once()
 
 		actualError := h.service.Create(context.Background(), appeals)
-		time.Sleep(time.Millisecond)
 
 		s.Nil(actualError)
 		s.Equal(expectedResult, appeals)
@@ -1669,7 +1668,6 @@ func (s *ServiceTestSuite) TestCreate() {
 			h.mockProviderService.EXPECT().GrantAccess(mock.Anything, mock.Anything).Return(nil).Once()
 
 			err := h.service.Create(context.Background(), []*domain.Appeal{input}, appeal.CreateWithAdditionalAppeal())
-			time.Sleep(time.Millisecond)
 
 			s.NoError(err)
 			s.Equal("test-approval", input.Approvals[0].Name)

--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -131,13 +131,15 @@ func (s *Service) Update(ctx context.Context, payload *domain.Grant) error {
 	*payload = *grantDetails
 	s.logger.Info(ctx, "grant updated", "grant_id", grantDetails.ID, "updatedGrant", updatedGrant)
 
-	if err := s.auditLogger.Log(ctx, AuditKeyUpdate, map[string]interface{}{
-		"grant_id":      grantDetails.ID,
-		"payload":       updatedGrant,
-		"updated_grant": payload,
-	}); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyUpdate, map[string]interface{}{
+			"grant_id":      grantDetails.ID,
+			"payload":       updatedGrant,
+			"updated_grant": payload,
+		}); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	if previousOwner != updatedGrant.Owner {
 		go func() {
@@ -251,12 +253,14 @@ func (s *Service) Revoke(ctx context.Context, id, actor, reason string, opts ...
 
 	s.logger.Info(ctx, "grant revoked", "grant_id", id)
 
-	if err := s.auditLogger.Log(ctx, AuditKeyRevoke, map[string]interface{}{
-		"grant_id": id,
-		"reason":   reason,
-	}); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyRevoke, map[string]interface{}{
+			"grant_id": id,
+			"reason":   reason,
+		}); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	return grant, nil
 }

--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -132,6 +132,7 @@ func (s *Service) Update(ctx context.Context, payload *domain.Grant) error {
 	s.logger.Info(ctx, "grant updated", "grant_id", grantDetails.ID, "updatedGrant", updatedGrant)
 
 	go func() {
+		ctx := context.WithoutCancel(ctx)
 		if err := s.auditLogger.Log(ctx, AuditKeyUpdate, map[string]interface{}{
 			"grant_id":      grantDetails.ID,
 			"payload":       updatedGrant,
@@ -254,6 +255,7 @@ func (s *Service) Revoke(ctx context.Context, id, actor, reason string, opts ...
 	s.logger.Info(ctx, "grant revoked", "grant_id", id)
 
 	go func() {
+		ctx := context.WithoutCancel(ctx)
 		if err := s.auditLogger.Log(ctx, AuditKeyRevoke, map[string]interface{}{
 			"grant_id": id,
 			"reason":   reason,

--- a/core/policy/service.go
+++ b/core/policy/service.go
@@ -119,9 +119,11 @@ func (s *Service) Create(ctx context.Context, p *domain.Policy) error {
 			return err
 		}
 
-		if err := s.auditLogger.Log(ctx, AuditKeyPolicyCreate, p); err != nil {
-			s.logger.Error(ctx, "failed to record audit log", "error", err)
-		}
+		go func() {
+			if err := s.auditLogger.Log(ctx, AuditKeyPolicyCreate, p); err != nil {
+				s.logger.Error(ctx, "failed to record audit log", "error", err)
+			}
+		}()
 	}
 
 	if p.HasIAMConfig() {
@@ -229,9 +231,11 @@ func (s *Service) Update(ctx context.Context, p *domain.Policy) error {
 			return err
 		}
 
-		if err := s.auditLogger.Log(ctx, AuditKeyPolicyUpdate, p); err != nil {
-			s.logger.Error(ctx, "failed to record audit log", "error", err)
-		}
+		go func() {
+			if err := s.auditLogger.Log(ctx, AuditKeyPolicyUpdate, p); err != nil {
+				s.logger.Error(ctx, "failed to record audit log", "error", err)
+			}
+		}()
 	}
 
 	if p.HasIAMConfig() {

--- a/core/policy/service_test.go
+++ b/core/policy/service_test.go
@@ -420,8 +420,6 @@ func (s *ServiceTestSuite) TestCreate() {
 
 			s.Nil(actualError)
 			s.mockPolicyRepository.AssertNotCalled(s.T(), "Create")
-			time.Sleep(time.Millisecond)
-			s.mockAuditLogger.AssertNotCalled(s.T(), "Log")
 		})
 	})
 }

--- a/core/policy/service_test.go
+++ b/core/policy/service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
@@ -401,6 +402,7 @@ func (s *ServiceTestSuite) TestCreate() {
 		s.Nil(actualError)
 		s.Equal(expectedVersion, validPolicy.Version)
 		s.mockPolicyRepository.AssertExpectations(s.T())
+		time.Sleep(time.Millisecond)
 		s.mockAuditLogger.AssertExpectations(s.T())
 		s.mockCrypto.AssertExpectations(s.T())
 	})
@@ -418,6 +420,7 @@ func (s *ServiceTestSuite) TestCreate() {
 
 			s.Nil(actualError)
 			s.mockPolicyRepository.AssertNotCalled(s.T(), "Create")
+			time.Sleep(time.Millisecond)
 			s.mockAuditLogger.AssertNotCalled(s.T(), "Log")
 		})
 	})
@@ -868,6 +871,7 @@ func (s *ServiceTestSuite) TestUpdate() {
 
 		s.Equal(expectedNewVersion, p.Version)
 		s.mockPolicyRepository.AssertExpectations(s.T())
+		time.Sleep(time.Millisecond)
 		s.mockAuditLogger.AssertExpectations(s.T())
 		s.mockCrypto.AssertExpectations(s.T())
 	})

--- a/core/provider/service.go
+++ b/core/provider/service.go
@@ -143,6 +143,7 @@ func (s *Service) Create(ctx context.Context, p *domain.Provider) error {
 		}
 
 		go func() {
+			ctx := context.WithoutCancel(ctx)
 			if err := s.auditLogger.Log(ctx, AuditKeyCreate, p); err != nil {
 				s.logger.Error(ctx, "failed to record audit log", "error", err)
 			}
@@ -226,6 +227,7 @@ func (s *Service) Update(ctx context.Context, p *domain.Provider) error {
 		}
 
 		go func() {
+			ctx := context.WithoutCancel(ctx)
 			if err := s.auditLogger.Log(ctx, AuditKeyUpdate, p); err != nil {
 				s.logger.Error(ctx, "failed to record audit log", "error", err)
 			}
@@ -475,6 +477,7 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	s.logger.Info(ctx, "provider deleted", "provider", id)
 
 	go func() {
+		ctx := context.WithoutCancel(ctx)
 		if err := s.auditLogger.Log(ctx, AuditKeyDelete, p); err != nil {
 			s.logger.Error(ctx, "failed to record audit log", "error", err)
 		}

--- a/core/provider/service.go
+++ b/core/provider/service.go
@@ -142,9 +142,11 @@ func (s *Service) Create(ctx context.Context, p *domain.Provider) error {
 			return err
 		}
 
-		if err := s.auditLogger.Log(ctx, AuditKeyCreate, p); err != nil {
-			s.logger.Error(ctx, "failed to record audit log", "error", err)
-		}
+		go func() {
+			if err := s.auditLogger.Log(ctx, AuditKeyCreate, p); err != nil {
+				s.logger.Error(ctx, "failed to record audit log", "error", err)
+			}
+		}()
 	} else {
 		s.logger.Info(ctx, "dry run enabled, skipping provider creation", "provider_urn", p.URN)
 	}
@@ -223,9 +225,11 @@ func (s *Service) Update(ctx context.Context, p *domain.Provider) error {
 			return err
 		}
 
-		if err := s.auditLogger.Log(ctx, AuditKeyUpdate, p); err != nil {
-			s.logger.Error(ctx, "failed to record audit log", "error", err)
-		}
+		go func() {
+			if err := s.auditLogger.Log(ctx, AuditKeyUpdate, p); err != nil {
+				s.logger.Error(ctx, "failed to record audit log", "error", err)
+			}
+		}()
 	} else {
 		s.logger.Info(ctx, "dry run enabled, skipping provider update", "provider_urn", p.URN)
 	}
@@ -470,9 +474,11 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	}
 	s.logger.Info(ctx, "provider deleted", "provider", id)
 
-	if err := s.auditLogger.Log(ctx, AuditKeyDelete, p); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyDelete, p); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	return nil
 }

--- a/core/provider/service_test.go
+++ b/core/provider/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/google/go-cmp/cmp"
@@ -141,6 +142,7 @@ func (s *ServiceTestSuite) TestCreate() {
 
 		s.Nil(actualError)
 		s.mockProviderRepository.AssertExpectations(s.T())
+		time.Sleep(time.Millisecond)
 		s.mockAuditLogger.AssertExpectations(s.T())
 	})
 

--- a/core/provider/service_test.go
+++ b/core/provider/service_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/google/go-cmp/cmp"
@@ -142,8 +141,6 @@ func (s *ServiceTestSuite) TestCreate() {
 
 		s.Nil(actualError)
 		s.mockProviderRepository.AssertExpectations(s.T())
-		time.Sleep(time.Millisecond)
-		s.mockAuditLogger.AssertExpectations(s.T())
 	})
 
 	s.Run("with dryRun true", func() {

--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -78,9 +78,11 @@ func (s *Service) BulkUpsert(ctx context.Context, resources []*domain.Resource) 
 		return err
 	}
 
-	if err := s.auditLogger.Log(ctx, AuditKeyResoruceBulkUpsert, resources); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyResoruceBulkUpsert, resources); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	return nil
 }
@@ -119,9 +121,11 @@ func (s *Service) Update(ctx context.Context, r *domain.Resource) error {
 
 	r.UpdatedAt = res.UpdatedAt
 
-	if err := s.auditLogger.Log(ctx, AuditKeyResourceUpdate, r); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyResourceUpdate, r); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	return nil
 }
@@ -160,9 +164,11 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	}
 	s.logger.Info(ctx, "resource deleted", "resource", id)
 
-	if err := s.auditLogger.Log(ctx, AuditKeyResourceDelete, map[string]interface{}{"id": id}); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyResourceDelete, map[string]interface{}{"id": id}); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	return nil
 }
@@ -174,9 +180,11 @@ func (s *Service) BatchDelete(ctx context.Context, ids []string) error {
 	}
 	s.logger.Info(ctx, "resources deleted", "resources", len(ids))
 
-	if err := s.auditLogger.Log(ctx, AuditKeyResourceBatchDelete, map[string]interface{}{"ids": ids}); err != nil {
-		s.logger.Error(ctx, "failed to record audit log", "error", err)
-	}
+	go func() {
+		if err := s.auditLogger.Log(ctx, AuditKeyResourceBatchDelete, map[string]interface{}{"ids": ids}); err != nil {
+			s.logger.Error(ctx, "failed to record audit log", "error", err)
+		}
+	}()
 
 	return nil
 }


### PR DESCRIPTION
**Summary**
Sending notifications should be not be part of sync call as part of create appeal or update approval. For both these steps, audit log and sending notifications need not be part of synchronous call one by one since that would increase the entire time of the appeal flow. These two can be run concurrently.
_Please refer to the issue #84 for the discussion._

**Approach**
Making the call async for audit log by applying go concurrency when sending the message through audit logger