### PR TITLE
fix(approval): restrict add/remove approver on stale approval

### DIFF
--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -1123,6 +1123,9 @@ func (s *Service) AddApprover(ctx context.Context, appealID, approvalID, email s
 	if appeal.Status != domain.AppealStatusPending {
 		return nil, fmt.Errorf("%w: can't add new approver to appeal with %q status", ErrUnableToAddApprover, appeal.Status)
 	}
+	if approval.IsStale {
+		return nil, fmt.Errorf("%w: can't add new approver to a stale approval", ErrUnableToAddApprover)
+	}
 	for _, existingApprover := range approval.Approvers {
 		if email == existingApprover {
 			return nil, fmt.Errorf("%w: approver %q already exists", ErrUnableToAddApprover, email)
@@ -1217,6 +1220,9 @@ func (s *Service) DeleteApprover(ctx context.Context, appealID, approvalID, emai
 	}
 	if appeal.Status != domain.AppealStatusPending {
 		return nil, fmt.Errorf("%w: can't delete approver to appeal with %q status", ErrUnableToDeleteApprover, appeal.Status)
+	}
+	if approval.IsStale {
+		return nil, fmt.Errorf("%w: can't delete approver in a stale approval", ErrUnableToDeleteApprover)
 	}
 
 	switch approval.Status {

--- a/domain/appeal.go
+++ b/domain/appeal.go
@@ -134,9 +134,12 @@ func (a *Appeal) SetDefaults() {
 	}
 }
 
-func (a *Appeal) GetApproval(id string) *Approval {
+// GetApproval returns an approval within the appeal.
+// If the ID is provided, it will return the approval with the given ID.
+// If the name is provided, it will return the approval with the given name AND !is_stale.
+func (a *Appeal) GetApproval(identifier string) *Approval {
 	for _, approval := range a.Approvals {
-		if approval.ID == id || approval.Name == id {
+		if approval.ID == identifier || (approval.Name == identifier && !approval.IsStale) {
 			return approval
 		}
 	}

--- a/domain/appeal_test.go
+++ b/domain/appeal_test.go
@@ -193,13 +193,21 @@ func TestAppeal_GetApproval(t *testing.T) {
 			appeal: &domain.Appeal{
 				Approvals: []*domain.Approval{
 					{
-						ID: "approval-1",
+						ID:      "approval_id_1",
+						Name:    "approval_name",
+						IsStale: true,
+					},
+					{
+						ID:   "approval_id_2",
+						Name: "approval_name",
 					},
 				},
 			},
-			id: "approval-1",
+			id: "approval_id_1",
 			want: &domain.Approval{
-				ID: "approval-1",
+				ID:      "approval_id_1",
+				Name:    "approval_name",
+				IsStale: true,
 			},
 		},
 		{
@@ -207,12 +215,33 @@ func TestAppeal_GetApproval(t *testing.T) {
 			appeal: &domain.Appeal{
 				Approvals: []*domain.Approval{
 					{
-						ID: "approval-1",
+						ID: "approval_id_1",
 					},
 				},
 			},
 			id:   "non-existing",
 			want: nil,
+		},
+		{
+			name: "return the non-stale approval with the given name",
+			appeal: &domain.Appeal{
+				Approvals: []*domain.Approval{
+					{
+						ID:      "approval_id_1",
+						Name:    "approval_name",
+						IsStale: true,
+					},
+					{
+						ID:   "approval_id_2",
+						Name: "approval_name",
+					},
+				},
+			},
+			id: "approval_name",
+			want: &domain.Approval{
+				ID:   "approval_id_2",
+				Name: "approval_name",
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
`approval`.`is_stale` is introduced in https://github.com/goto/guardian/pull/150 and this new field hasn't accounted for the approver addition or removal yet. This PR handle add/remove approval with `is_stale`