### PR TITLE
chore: add lazyinstrument for otel metrics & add detected drift metrics

### DIFF
--- a/core/grant/metrics.go
+++ b/core/grant/metrics.go
@@ -1,14 +1,15 @@
 package grant
 
 import (
-	"go.opentelemetry.io/otel"
+	guardianotel "github.com/goto/guardian/pkg/opentelemetry"
 	"go.opentelemetry.io/otel/metric"
 )
 
 const meterName = "github.com/goto/guardian/core/grant"
 
 var (
-	metricDriftRemediation, _ = otel.Meter(meterName).Int64Counter(
+	metricDriftRemediation = guardianotel.NewLazyInt64Counter(
+		meterName,
 		"grant_drift_remediation",
 		metric.WithDescription("Number of grants remediated due to drift, grouped by remediation status, resource URN, account ID, and provider type"),
 	)

--- a/core/grant/metrics.go
+++ b/core/grant/metrics.go
@@ -8,9 +8,15 @@ import (
 const meterName = "github.com/goto/guardian/core/grant"
 
 var (
+	metricDriftDetected = guardianotel.NewLazyInt64Counter(
+		meterName,
+		"grant_drift_detected",
+		metric.WithDescription("Number of grants detected with drift, grouped by resource URN, account ID, provider type, and role"),
+	)
+
 	metricDriftRemediation = guardianotel.NewLazyInt64Counter(
 		meterName,
 		"grant_drift_remediation",
-		metric.WithDescription("Number of grants remediated due to drift, grouped by remediation status, resource URN, account ID, and provider type"),
+		metric.WithDescription("Number of grants remediated due to drift, grouped by remediation status, resource URN, account ID, provider type, and role"),
 	)
 )

--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -1164,8 +1164,9 @@ func (s *Service) detectDriftedGrants(ctx context.Context, botAccountIDs []strin
 	// What remains here will be the drifted grants
 	drifted := activeGrantsMap.Flatten()
 	// publish metric for drifted grants count
+	driftDetectedCounter := metricDriftDetected.Get()
 	for _, g := range drifted {
-		metricDriftDetected.Get().Add(ctx, 1,
+		driftDetectedCounter.Add(ctx, 1,
 			metric.WithAttributes(
 				attribute.String("provider_urn", g.Resource.ProviderURN),
 				attribute.String("resource_urn", g.Resource.URN),

--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -1089,6 +1089,16 @@ func (s *Service) remediateDriftedGrant(ctx context.Context, g domain.Grant) dom
 		remediationStatus = "recreated"
 	}
 
+	// Emit the metric on the main path so short-lived jobs do not exit before export.
+	metricDriftRemediation.Get().Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("status", remediationStatus),
+			attribute.String("provider_urn", g.Resource.ProviderURN),
+			attribute.String("resource_urn", g.Resource.URN),
+			attribute.String("account_id", g.AccountID),
+		),
+	)
+
 	go func() {
 		auditCtx := context.WithoutCancel(ctx)
 		auditData := map[string]interface{}{
@@ -1101,16 +1111,6 @@ func (s *Service) remediateDriftedGrant(ctx context.Context, g domain.Grant) dom
 		if err := s.auditLogger.Log(auditCtx, AuditKeyDriftRemediaton, auditData); err != nil {
 			s.logger.Error(ctx, "failed to record drift remediation audit log", "error", err)
 		}
-
-		// send metrics for monitoring drift remediation outcomes
-		metricDriftRemediation.Add(ctx, 1,
-			metric.WithAttributes(
-				attribute.String("status", remediationStatus),
-				attribute.String("provider_urn", g.Resource.ProviderURN),
-				attribute.String("resource_urn", g.Resource.URN),
-				attribute.String("account_id", g.AccountID),
-			),
-		)
 	}()
 
 	return issue

--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -1096,6 +1096,7 @@ func (s *Service) remediateDriftedGrant(ctx context.Context, g domain.Grant) dom
 			attribute.String("resource_urn", g.Resource.URN),
 			attribute.String("account_id", g.AccountID),
 			attribute.String("grant_id", g.ID),
+			attribute.String("role", g.Role),
 		),
 	)
 
@@ -1162,6 +1163,18 @@ func (s *Service) detectDriftedGrants(ctx context.Context, botAccountIDs []strin
 
 	// What remains here will be the drifted grants
 	drifted := activeGrantsMap.Flatten()
+	// publish metric for drifted grants count
+	for _, g := range drifted {
+		metricDriftDetected.Get().Add(ctx, 1,
+			metric.WithAttributes(
+				attribute.String("provider_urn", g.Resource.ProviderURN),
+				attribute.String("resource_urn", g.Resource.URN),
+				attribute.String("account_id", g.AccountID),
+				attribute.String("grant_id", g.ID),
+				attribute.String("role", g.Role),
+			),
+		)
+	}
 
 	s.logger.Info(ctx, "drift detection complete",
 		"active_grants_checked", len(activeGrants),

--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -1089,13 +1089,13 @@ func (s *Service) remediateDriftedGrant(ctx context.Context, g domain.Grant) dom
 		remediationStatus = "recreated"
 	}
 
-	// Emit the metric on the main path so short-lived jobs do not exit before export.
 	metricDriftRemediation.Get().Add(ctx, 1,
 		metric.WithAttributes(
 			attribute.String("status", remediationStatus),
 			attribute.String("provider_urn", g.Resource.ProviderURN),
 			attribute.String("resource_urn", g.Resource.URN),
 			attribute.String("account_id", g.AccountID),
+			attribute.String("grant_id", g.ID),
 		),
 	)
 

--- a/jobs/grant_drift_check.go
+++ b/jobs/grant_drift_check.go
@@ -46,6 +46,6 @@ func (h *handler) GrantDriftCheck(ctx context.Context, c Config) error {
 
 	start := time.Now()
 	err := h.grantService.GrantDriftCheck(ctx, req)
-	histGrantDriftCheckDuration.Record(ctx, float64(time.Since(start).Milliseconds()))
+	histGrantDriftCheckDuration.Get().Record(ctx, float64(time.Since(start).Milliseconds()))
 	return err
 }

--- a/jobs/metrics.go
+++ b/jobs/metrics.go
@@ -1,14 +1,15 @@
 package jobs
 
 import (
-	"go.opentelemetry.io/otel"
+	guardianotel "github.com/goto/guardian/pkg/opentelemetry"
 	"go.opentelemetry.io/otel/metric"
 )
 
 const meterName = "github.com/goto/guardian/jobs"
 
 var (
-	histGrantDriftCheckDuration, _ = otel.Meter(meterName).Float64Histogram(
+	histGrantDriftCheckDuration = guardianotel.NewLazyFloat64Histogram(
+		meterName,
 		"grant_drift_check_duration",
 		metric.WithDescription("Duration of the grant drift check job in milliseconds"),
 		metric.WithUnit("ms"),

--- a/pkg/opentelemetry/lazy_instrument.go
+++ b/pkg/opentelemetry/lazy_instrument.go
@@ -1,0 +1,43 @@
+package opentelemetry
+
+import (
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	metricapi "go.opentelemetry.io/otel/metric"
+)
+
+type LazyInstrument[T any] struct {
+	meterName string
+	build     func(metricapi.Meter) (T, error)
+
+	once  sync.Once
+	value T
+}
+
+func NewLazyInstrument[T any](meterName string, build func(metricapi.Meter) (T, error)) *LazyInstrument[T] {
+	return &LazyInstrument[T]{
+		meterName: meterName,
+		build:     build,
+	}
+}
+
+func (i *LazyInstrument[T]) Get() T {
+	i.once.Do(func() {
+		i.value, _ = i.build(otel.Meter(i.meterName))
+	})
+
+	return i.value
+}
+
+func NewLazyInt64Counter(meterName string, name string, options ...metricapi.Int64CounterOption) *LazyInstrument[metricapi.Int64Counter] {
+	return NewLazyInstrument(meterName, func(meter metricapi.Meter) (metricapi.Int64Counter, error) {
+		return meter.Int64Counter(name, options...)
+	})
+}
+
+func NewLazyFloat64Histogram(meterName string, name string, options ...metricapi.Float64HistogramOption) *LazyInstrument[metricapi.Float64Histogram] {
+	return NewLazyInstrument(meterName, func(meter metricapi.Meter) (metricapi.Float64Histogram, error) {
+		return meter.Float64Histogram(name, options...)
+	})
+}


### PR DESCRIPTION
Initialize metrics with opentelemetry lazy instrument so that metrics are ensured to always be initialized once the meter provider is initialized as well.