### PR TITLE
Fix Shield self-user approval panic

### DIFF
--- a/plugins/providers/shield/client.go
+++ b/plugins/providers/shield/client.go
@@ -366,6 +366,12 @@ func (c *client) GetSelfUser(ctx context.Context, email string) (*User, error) {
 	if v, ok := response.(map[string]interface{}); ok && v[userConst] != nil {
 		err = mapstructure.Decode(v[userConst], &user)
 	}
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, fmt.Errorf("shield self user response missing user for email %q", email)
+	}
 
 	c.logger.Info(ctx, "Fetch user from request", "Id", user.ID, req.URL)
 
@@ -380,9 +386,9 @@ func (c *client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusInternalServerError {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		byteData, _ := io.ReadAll(resp.Body)
-		return nil, errors.New(string(byteData))
+		return nil, fmt.Errorf("request to %s failed with status %d: %s", req.URL, resp.StatusCode, string(byteData))
 	}
 
 	if v != nil {

--- a/plugins/providers/shield/client_new.go
+++ b/plugins/providers/shield/client_new.go
@@ -515,6 +515,12 @@ func (c *shieldNewclient) GetSelfUser(ctx context.Context, email string) (*User,
 	if v, ok := response.(map[string]interface{}); ok && v[userConst] != nil {
 		err = mapstructure.Decode(v[userConst], &user)
 	}
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, fmt.Errorf("shield self user response missing user for email %q", email)
+	}
 
 	c.logger.Info(ctx, "Fetch user from new shield request", "Id", user.ID, req.URL)
 

--- a/plugins/providers/shield/client_new_test.go
+++ b/plugins/providers/shield/client_new_test.go
@@ -835,6 +835,24 @@ func (s *ShieldNewClientTestSuite) TestShieldNewGetSelfUser() {
 		s.EqualValues(expectedUser, user)
 		s.Nil(actualError)
 	})
+	s.Run("Should return error when response misses user payload", func() {
+		s.setup()
+		testUserEmail := "test_user@email.com"
+
+		testGetSelfRequest, err := s.getTestRequest(http.MethodGet, "/admin/v1beta1/users/self", nil, testUserEmail)
+		s.Require().NoError(err)
+
+		responseJson := `{
+			"message": "user not found"
+		}`
+
+		responseUser := http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader([]byte(responseJson)))}
+		s.mockHttpClient.On("Do", testGetSelfRequest).Return(&responseUser, nil).Once()
+
+		user, actualError := s.client.GetSelfUser(context.Background(), testUserEmail)
+		s.Nil(user)
+		s.EqualError(actualError, `shield self user response missing user for email "test_user@email.com"`)
+	})
 }
 
 func (s *ShieldNewClientTestSuite) TestCreateTeam() {

--- a/plugins/providers/shield/client_test.go
+++ b/plugins/providers/shield/client_test.go
@@ -603,6 +603,24 @@ func (s *ClientTestSuite) TestGetSelfUser() {
 		s.EqualValues(expectedUser, user)
 		s.Nil(actualError)
 	})
+	s.Run("Should return error when response misses user payload", func() {
+		s.setup()
+		testUserEmail := "test_user@email.com"
+
+		testGetSelfRequest, err := s.getTestRequest(http.MethodGet, "/admin/v1beta1/users/self", nil, testUserEmail)
+		s.Require().NoError(err)
+
+		responseJson := `{
+			"message": "user not found"
+		}`
+
+		responseUser := http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader([]byte(responseJson)))}
+		s.mockHttpClient.On("Do", testGetSelfRequest).Return(&responseUser, nil).Once()
+
+		user, actualError := s.client.GetSelfUser(context.Background(), testUserEmail)
+		s.Nil(user)
+		s.EqualError(actualError, `shield self user response missing user for email "test_user@email.com"`)
+	})
 }
 func (s *ClientTestSuite) TestRevokeResourceAccess() {
 	s.Run("should return error and log info", func() {

--- a/plugins/providers/shield/provider.go
+++ b/plugins/providers/shield/provider.go
@@ -236,7 +236,10 @@ func (p *provider) GrantAccess(ctx context.Context, pc *domain.ProviderConfig, a
 
 	var user *User
 	if user, err = client.GetSelfUser(ctx, a.AccountID); err != nil {
-		return nil
+		return fmt.Errorf("getting shield user %q: %w", a.AccountID, err)
+	}
+	if user == nil {
+		return fmt.Errorf("getting shield user %q: empty user response", a.AccountID)
 	}
 
 	switch a.Resource.Type {
@@ -330,7 +333,10 @@ func (p *provider) RevokeAccess(ctx context.Context, pc *domain.ProviderConfig, 
 
 	var user *User
 	if user, err = client.GetSelfUser(ctx, a.AccountID); err != nil {
-		return nil
+		return fmt.Errorf("getting shield user %q: %w", a.AccountID, err)
+	}
+	if user == nil {
+		return fmt.Errorf("getting shield user %q: empty user response", a.AccountID)
 	}
 
 	switch a.Resource.Type {

--- a/plugins/providers/shield/provider_test.go
+++ b/plugins/providers/shield/provider_test.go
@@ -494,6 +494,57 @@ func TestGrantAccess(t *testing.T) {
 	})
 
 	t.Run("given team resource", func(t *testing.T) {
+		t.Run("should return error if getting self user fails", func(t *testing.T) {
+			providerURN := "test-provider-urn"
+			expectedError := errors.New("client error")
+			client := new(mocks.ShieldClient)
+			logger := log.NewCtxLogger("info", []string{"test"})
+			p := shield.NewProvider("", logger)
+			p.Clients = map[string]shield.ShieldClient{
+				providerURN: client,
+			}
+
+			expectedUserEmail := "test@email.com"
+			client.On("GetSelfUser", mock.MatchedBy(func(ctx context.Context) bool { return true }), expectedUserEmail).Return(nil, expectedError).Once()
+
+			pc := &domain.ProviderConfig{
+				Credentials: shield.Credentials{
+					Host:      "localhost",
+					AuthEmail: "test_email",
+				},
+				Resources: []*domain.ResourceConfig{
+					{
+						Type: shield.ResourceTypeTeam,
+						Roles: []*domain.Role{
+							{
+								ID:          "test-role",
+								Permissions: []interface{}{"test-permission-config"},
+							},
+						},
+					},
+				},
+				URN: providerURN,
+			}
+			a := domain.Grant{
+				Resource: &domain.Resource{
+					Type: shield.ResourceTypeTeam,
+					URN:  "team:team_id",
+					Name: "team_1",
+					Details: map[string]interface{}{
+						"id":    "team_id",
+						"orgId": "456",
+					},
+				},
+				Role:        "test-role",
+				AccountID:   expectedUserEmail,
+				Permissions: []string{"test-permission-config"},
+			}
+
+			actualError := p.GrantAccess(ctx, pc, a)
+
+			assert.EqualError(t, actualError, `getting shield user "test@email.com": client error`)
+		})
+
 		t.Run("should return error if there is an error in granting team access", func(t *testing.T) {
 			providerURN := "test-provider-urn"
 			expectedError := errors.New("client error")
@@ -1100,6 +1151,57 @@ func TestRevokeAccess(t *testing.T) {
 	})
 
 	t.Run("given team resource", func(t *testing.T) {
+		t.Run("should return error if getting self user fails", func(t *testing.T) {
+			providerURN := "test-provider-urn"
+			expectedError := errors.New("client error")
+			client := new(mocks.ShieldClient)
+			logger := log.NewCtxLogger("info", []string{"test"})
+			p := shield.NewProvider("", logger)
+			p.Clients = map[string]shield.ShieldClient{
+				providerURN: client,
+			}
+
+			expectedUserEmail := "test@email.com"
+			client.On("GetSelfUser", mockCtx, expectedUserEmail).Return(nil, expectedError).Once()
+
+			pc := &domain.ProviderConfig{
+				Credentials: shield.Credentials{
+					Host:      "localhost",
+					AuthEmail: "test_email",
+				},
+				Resources: []*domain.ResourceConfig{
+					{
+						Type: shield.ResourceTypeTeam,
+						Roles: []*domain.Role{
+							{
+								ID:          "test-role",
+								Permissions: []interface{}{"test-permission-config"},
+							},
+						},
+					},
+				},
+				URN: providerURN,
+			}
+			a := domain.Grant{
+				Resource: &domain.Resource{
+					Type: shield.ResourceTypeTeam,
+					URN:  "team:team_id",
+					Name: "team_1",
+					Details: map[string]interface{}{
+						"id":    "team_id",
+						"orgId": "456",
+					},
+				},
+				Role:        "test-role",
+				AccountID:   expectedUserEmail,
+				Permissions: []string{"test-permission-config"},
+			}
+
+			actualError := p.RevokeAccess(ctx, pc, a)
+
+			assert.EqualError(t, actualError, `getting shield user "test@email.com": client error`)
+		})
+
 		t.Run("should return error if there is an error in revoking team access", func(t *testing.T) {
 			providerURN := "test-provider-urn"
 			expectedError := errors.New("client error")


### PR DESCRIPTION
## Summary
- return an explicit error when Shield self-user lookup does not return a `user` payload
- treat all non-2xx responses from the old Shield client as errors
- propagate Shield self-user lookup failures from grant and revoke instead of swallowing them
- add regression tests for missing self-user payloads and provider error propagation

## Root cause
Approving the final `team_admin_approval` step immediately provisions Shield access. When the Shield self-user lookup for the target appeal account returned a non-success or an unexpected body, Guardian dereferenced `user.ID` and panicked, so approvers only saw `Internal error, please check log` instead of the actual Shield failure.

## Testing
- `gofmt -w plugins/providers/shield/client.go plugins/providers/shield/client_new.go plugins/providers/shield/provider.go plugins/providers/shield/client_test.go plugins/providers/shield/client_new_test.go plugins/providers/shield/provider_test.go`
- `/Users/haryo.assyafah/sdk/go1.25.6/bin/go test -mod=mod ./plugins/providers/shield`
