### PR TITLE
feat: evaluate all approval steps when appeal is created

### DIFF
--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -1632,6 +1632,21 @@ func (s *Service) AddApprovalStep(ctx context.Context, appealID string, steps []
 			}
 		}
 
+		// If the step is blocked, eagerly evaluate its 'when' condition. A falsy
+		// result skips the step immediately rather than waiting for prior steps to resolve.
+		if step.Status == domain.ApprovalStatusBlocked {
+			stepConfig := policy.GetStepByName(step.Name)
+			if stepConfig != nil && stepConfig.When != "" {
+				isFalsy, err := evaluateIsFalsyExpressionWithAppeal(appeal, stepConfig.When)
+				if err != nil {
+					return nil, fmt.Errorf("evaluating 'when' condition for step %q: %w", step.Name, err)
+				}
+				if isFalsy {
+					step.Status = domain.ApprovalStatusSkipped
+				}
+			}
+		}
+
 		step.AppealID = appealID
 		step.AppealRevision = appeal.Revision
 		toInsert = append(toInsert, step)

--- a/domain/appeal.go
+++ b/domain/appeal.go
@@ -353,6 +353,37 @@ func (a *Appeal) AdvanceApproval(policy *Policy) error {
 		return fmt.Errorf("appeal has no policy")
 	}
 
+	// Pre-pass: eagerly evaluate 'when' for all blocked steps. Steps whose
+	// condition is false are skipped immediately rather than waiting for all
+	// prior steps to be approved first. An evaluation error fails immediately.
+	{
+		appealMap, err := a.ToMap()
+		if err != nil {
+			return fmt.Errorf("parsing appeal struct to map: %w", err)
+		}
+		for _, approval := range a.Approvals {
+			if approval.IsStale || approval.Status != ApprovalStatusBlocked {
+				continue
+			}
+			stepConfig := policy.GetStepByName(approval.Name)
+			if (stepConfig == nil || approval.Name == "") && !policy.HasStages() && approval.Index < len(policy.Steps) {
+				stepConfig = policy.Steps[approval.Index]
+			}
+			if stepConfig == nil || stepConfig.When == "" {
+				continue
+			}
+			v, err := evaluator.Expression(stepConfig.When).EvaluateWithVars(map[string]interface{}{
+				"appeal": appealMap,
+			})
+			if err != nil {
+				return err
+			}
+			if reflect.ValueOf(v).IsZero() {
+				approval.Status = ApprovalStatusSkipped
+			}
+		}
+	}
+
 	sortedIndices := a.GetSortedStageIndices()
 
 	for idxPos, stageIdx := range sortedIndices {

--- a/domain/appeal.go
+++ b/domain/appeal.go
@@ -352,6 +352,19 @@ func (a *Appeal) ApplyPolicy(p *Policy) error {
 // For stage-based policies it matches by name only. For sequential policies it
 // additionally falls back to the step at the same positional index when the
 // name lookup fails (handles dynamically-built or empty-name steps).
+func evaluateWhen(stepConfig *Step, appealMap map[string]interface{}) (bool, error) {
+	if stepConfig.When == "" {
+		return false, nil
+	}
+	v, err := evaluator.Expression(stepConfig.When).EvaluateWithVars(map[string]interface{}{
+		"appeal": appealMap,
+	})
+	if err != nil {
+		return false, err
+	}
+	return reflect.ValueOf(v).IsZero(), nil
+}
+
 func getStepConfig(policy *Policy, approval *Approval) *Step {
 	stepConfig := policy.GetStepByName(approval.Name)
 	if (stepConfig == nil || approval.Name == "") && !policy.HasStages() && approval.Index < len(policy.Steps) {
@@ -381,13 +394,11 @@ func (a *Appeal) AdvanceApproval(policy *Policy) error {
 		if stepConfig == nil || stepConfig.When == "" {
 			continue
 		}
-		v, err := evaluator.Expression(stepConfig.When).EvaluateWithVars(map[string]interface{}{
-			"appeal": appealMap,
-		})
+		skip, err := evaluateWhen(stepConfig, appealMap)
 		if err != nil {
 			return err
 		}
-		if reflect.ValueOf(v).IsZero() {
+		if skip {
 			approval.Status = ApprovalStatusSkipped
 		}
 	}
@@ -407,17 +418,13 @@ func (a *Appeal) AdvanceApproval(policy *Policy) error {
 				continue
 			}
 
-			if stepConfig.When != "" {
-				v, err := evaluator.Expression(stepConfig.When).EvaluateWithVars(map[string]interface{}{
-					"appeal": appealMap,
-				})
-				if err != nil {
-					return err
-				}
-				if reflect.ValueOf(v).IsZero() {
-					approval.Status = ApprovalStatusSkipped
-					continue
-				}
+			skip, err := evaluateWhen(stepConfig, appealMap)
+			if err != nil {
+				return err
+			}
+			if skip {
+				approval.Status = ApprovalStatusSkipped
+				continue
 			}
 
 			if stepConfig.Strategy == ApprovalStepStrategyAuto {

--- a/domain/appeal.go
+++ b/domain/appeal.go
@@ -348,39 +348,47 @@ func (a *Appeal) ApplyPolicy(p *Policy) error {
 	return nil
 }
 
+// getStepConfig resolves the policy Step for a given approval.
+// For stage-based policies it matches by name only. For sequential policies it
+// additionally falls back to the step at the same positional index when the
+// name lookup fails (handles dynamically-built or empty-name steps).
+func getStepConfig(policy *Policy, approval *Approval) *Step {
+	stepConfig := policy.GetStepByName(approval.Name)
+	if (stepConfig == nil || approval.Name == "") && !policy.HasStages() && approval.Index < len(policy.Steps) {
+		stepConfig = policy.Steps[approval.Index]
+	}
+	return stepConfig
+}
+
 func (a *Appeal) AdvanceApproval(policy *Policy) error {
 	if policy == nil {
 		return fmt.Errorf("appeal has no policy")
 	}
 
+	appealMap, err := a.ToMap()
+	if err != nil {
+		return fmt.Errorf("parsing appeal struct to map: %w", err)
+	}
+
 	// Pre-pass: eagerly evaluate 'when' for all blocked steps. Steps whose
 	// condition is false are skipped immediately rather than waiting for all
 	// prior steps to be approved first. An evaluation error fails immediately.
-	{
-		appealMap, err := a.ToMap()
-		if err != nil {
-			return fmt.Errorf("parsing appeal struct to map: %w", err)
+	for _, approval := range a.Approvals {
+		if approval.IsStale || approval.Status != ApprovalStatusBlocked {
+			continue
 		}
-		for _, approval := range a.Approvals {
-			if approval.IsStale || approval.Status != ApprovalStatusBlocked {
-				continue
-			}
-			stepConfig := policy.GetStepByName(approval.Name)
-			if (stepConfig == nil || approval.Name == "") && !policy.HasStages() && approval.Index < len(policy.Steps) {
-				stepConfig = policy.Steps[approval.Index]
-			}
-			if stepConfig == nil || stepConfig.When == "" {
-				continue
-			}
-			v, err := evaluator.Expression(stepConfig.When).EvaluateWithVars(map[string]interface{}{
-				"appeal": appealMap,
-			})
-			if err != nil {
-				return err
-			}
-			if reflect.ValueOf(v).IsZero() {
-				approval.Status = ApprovalStatusSkipped
-			}
+		stepConfig := getStepConfig(policy, approval)
+		if stepConfig == nil || stepConfig.When == "" {
+			continue
+		}
+		v, err := evaluator.Expression(stepConfig.When).EvaluateWithVars(map[string]interface{}{
+			"appeal": appealMap,
+		})
+		if err != nil {
+			return err
+		}
+		if reflect.ValueOf(v).IsZero() {
+			approval.Status = ApprovalStatusSkipped
 		}
 	}
 
@@ -394,22 +402,9 @@ func (a *Appeal) AdvanceApproval(policy *Policy) error {
 				continue
 			}
 
-			stepConfig := policy.GetStepByName(approval.Name)
-			// For sequential (non-stage) policies, fall back to the step at the same
-			// positional index. The empty-name guard re-applies the positional lookup
-			// when multiple steps share an empty name (e.g. dynamically-built policies).
-			// Skip this fallback for stage-based policies: index no longer equals slice
-			// position, so a dynamically-added step without a policy entry stays manual.
-			if (stepConfig == nil || approval.Name == "") && !policy.HasStages() && approval.Index < len(policy.Steps) {
-				stepConfig = policy.Steps[approval.Index]
-			}
+			stepConfig := getStepConfig(policy, approval)
 			if stepConfig == nil {
 				continue
-			}
-
-			appealMap, err := a.ToMap()
-			if err != nil {
-				return fmt.Errorf("parsing appeal struct to map: %w", err)
 			}
 
 			if stepConfig.When != "" {

--- a/domain/appeal_test.go
+++ b/domain/appeal_test.go
@@ -1222,6 +1222,122 @@ func TestAppeal_AdvanceApproval_UpdateApprovalStatuses(t *testing.T) {
 			expectedErrorStr: "evaluating expression ",
 		},
 		{
+			name: "blocked step with when=false is eagerly skipped",
+			appeal: &domain.Appeal{
+				Resource: &domain.Resource{
+					Details: map[string]interface{}{
+						"labels": "no-kyc",
+					},
+				},
+			},
+			steps: []*domain.Step{
+				{
+					Strategy:  "manual",
+					Approvers: []string{"manager@email.com"},
+				},
+				{
+					Strategy:  "manual",
+					When:      `$appeal.resource.details.labels == "kyc"`,
+					Approvers: []string{"kyc@email.com"},
+				},
+			},
+			existingApprovalStatuses: []string{
+				domain.ApprovalStatusPending,
+				domain.ApprovalStatusBlocked,
+			},
+			expectedApprovalStatuses: []string{
+				domain.ApprovalStatusPending,
+				domain.ApprovalStatusSkipped,
+			},
+		},
+		{
+			name: "blocked step with when=true stays blocked",
+			appeal: &domain.Appeal{
+				Resource: &domain.Resource{
+					Details: map[string]interface{}{
+						"labels": "kyc",
+					},
+				},
+			},
+			steps: []*domain.Step{
+				{
+					Strategy:  "manual",
+					Approvers: []string{"manager@email.com"},
+				},
+				{
+					Strategy:  "manual",
+					When:      `$appeal.resource.details.labels == "kyc"`,
+					Approvers: []string{"kyc@email.com"},
+				},
+			},
+			existingApprovalStatuses: []string{
+				domain.ApprovalStatusPending,
+				domain.ApprovalStatusBlocked,
+			},
+			expectedApprovalStatuses: []string{
+				domain.ApprovalStatusPending,
+				domain.ApprovalStatusBlocked,
+			},
+		},
+		{
+			name: "multiple blocked steps with when=false are all eagerly skipped",
+			appeal: &domain.Appeal{
+				Resource: &domain.Resource{
+					Details: map[string]interface{}{
+						"labels": "",
+					},
+				},
+			},
+			steps: []*domain.Step{
+				{
+					Strategy:  "manual",
+					Approvers: []string{"manager@email.com"},
+				},
+				{
+					Strategy:  "manual",
+					When:      `$appeal.resource.details.labels == "kyc"`,
+					Approvers: []string{"kyc@email.com"},
+				},
+				{
+					Strategy:  "manual",
+					When:      `$appeal.resource.details.labels == "wallet"`,
+					Approvers: []string{"wallet@email.com"},
+				},
+			},
+			existingApprovalStatuses: []string{
+				domain.ApprovalStatusPending,
+				domain.ApprovalStatusBlocked,
+				domain.ApprovalStatusBlocked,
+			},
+			expectedApprovalStatuses: []string{
+				domain.ApprovalStatusPending,
+				domain.ApprovalStatusSkipped,
+				domain.ApprovalStatusSkipped,
+			},
+		},
+		{
+			name: "blocked step with invalid when expression fails immediately",
+			appeal: &domain.Appeal{
+				Resource: &domain.Resource{},
+			},
+			steps: []*domain.Step{
+				{
+					Strategy:  "manual",
+					Approvers: []string{"manager@email.com"},
+				},
+				{
+					Strategy:  "manual",
+					When:      `$appeal.details != nil && $appeal.details.foo != nil && $appeal.details.bar != nil && $appeal.details.foo.foo contains "foo" || $appeal.details.foo.bar contains "bar"`,
+					Approvers: []string{"approver@email.com"},
+				},
+			},
+			existingApprovalStatuses: []string{
+				domain.ApprovalStatusPending,
+				domain.ApprovalStatusBlocked,
+			},
+			expectedErrorStr: "evaluating expression",
+		},
+		{
 			name: "custom steps - advance approval with multiple custom steps",
 			appeal: &domain.Appeal{
 				Status: domain.AppealStatusPending,


### PR DESCRIPTION
#### Changes

- AdvanceApproval now runs a pre-pass over all blocked approvals, evaluating when upfront. false -> skipped immediately. Expression error -> fails appeal creation.
- Same logic applied to dynamically-added steps in AddApprovalStep.

#### Not covered
- Steps skipped at creation are not re-evaluated if resource labels/details change later via Relabel or Patch.
- Dynamic steps without a matching policy entry are not evaluated.