### PR TITLE
ci: speed up release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,21 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21"
+          cache: true
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.6.1
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: v1.26.2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,14 +9,12 @@ builds:
   - id: "guardian"
     main: ./main.go
     binary: guardian
-    flags:
-      - -a
     ldflags:
       - -X github.com/goto/guardian/core.Version={{.Tag}}
       - -X github.com/goto/guardian/core.BuildCommit={{.FullCommit}}
       - -X github.com/goto/guardian/core.BuildDate={{.Date}}
     goos: [darwin, linux]
-    goarch: [amd64, 386, arm, arm64]
+    goarch: [amd64, arm64]
     env:
       - CGO_ENABLED=0
 archives:


### PR DESCRIPTION
- drop the `-a` build flag: it forced a full rebuild of the stdlib + all deps (ignoring the build cache) for every target; CGO_ENABLED=0 already yields static binaries, so it was redundant and the main cause of the ~8m release
- trim goarch to amd64+arm64 (drop 32-bit 386/arm) for both darwin and linux: fewer targets to compile; matches what docker/homebrew use
- actions/setup-go@v5 with cache: true to persist module + build caches across runs
- bump checkout@v4, docker/login-action@v3, goreleaser-action@v6