### PR TITLE
fix: bind snake_case job config keys to struct fields (e.g. filters.account_ids)

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -1,6 +1,8 @@
 package jobs
 
 import (
+	"strings"
+
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -26,5 +28,18 @@ type Job struct {
 type Config map[string]interface{}
 
 func (c Config) Decode(v interface{}) error {
-	return mapstructure.Decode(c, v)
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result: v,
+		// Config keys are typically snake_case (e.g. "account_ids") while struct
+		// fields are CamelCase (e.g. AccountIDs) with no mapstructure tag, so the
+		// default EqualFold matcher never binds them. Ignore underscores so any
+		// snake_case config key binds to its corresponding struct field.
+		MatchName: func(mapKey, fieldName string) bool {
+			return strings.EqualFold(strings.ReplaceAll(mapKey, "_", ""), fieldName)
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(c)
 }


### PR DESCRIPTION
## Summary
- `jobs.Config.Decode` used mapstructure's default `EqualFold` name matching,
  which is case-insensitive but does not account for underscores. Struct
  fields like `domain.ListGrantsFilter.AccountIDs` have no `mapstructure` tag
  (only a `json:"account_ids"` tag), so a config key of `account_ids` never
  bound to the `AccountIDs` field — it silently stayed nil.
- This broke `filters.account_ids` (and any other untagged snake_case filter
  field) in `JOBS_BOT_EXPIRATION_ALERT_CONFIG`: the bot expiration alert job
  ran against all accounts instead of the configured subset, since an empty
  `AccountIDs` filter means no `WHERE account_id IN (...)` clause is applied.
- Fix: use a custom `mapstructure.MatchName` that strips underscores before
  comparing, so snake_case config keys bind to their CamelCase struct fields
  without needing an explicit tag on every field.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] Reproduced the bug and verified the fix with a decode test: `filters.account_ids` now correctly resolves to the configured slice instead of nil
- [x] Verified no regression for already-tagged fields (e.g. `extract_bot_email` still binds via exact match)
- [x] Verified no field-name collisions introduced across `ListGrantsFilter` (74 fields) and `BotExpirationAlertConfig` (7 fields) under the new matcher
- [x] Confirmed blast radius is limited to `bot_expiration_alert`, the only job currently using `Config.Decode`

## Alternative considered: tagging every ListGrantsFilter field

Instead of changing the decoder's matching logic, we could add explicit
`mapstructure:"account_ids"`-style tags to each field in
`domain.ListGrantsFilter` (74 fields, only `Size`/`Offset`/`Q` currently
have one) so they match their `json` tags. We went with the generic
`MatchName` fix instead:

- **Self-maintaining vs. per-field discipline.** `ListGrantsFilter` is a
  large, actively-growing shared struct. Tagging fixes only the fields
  tagged today — any new field added later without a matching
  `mapstructure` tag reintroduces this exact bug, silently (mapstructure
  doesn't error on unmatched keys). The `MatchName` fix handles snake_case
  keys generically, so it keeps working without anyone remembering to tag
  the next field.
- **Blast radius is already minimal.** `jobs.Config.Decode` is currently
  only called from `bot_expiration_alert.go`, so the change only affects
  this one job's config path today, with the added benefit of covering
  any future job that decodes filters from config the same way.
- **No regression risk for tagged fields.** mapstructure resolves an exact
  key match against a field's tag before ever falling back to `MatchName`,
  so already-tagged fields (e.g. `extract_bot_email`) are unaffected —
  verified with a decode test.
- **No collision risk.** Checked all 74 `ListGrantsFilter` fields and 7
  `BotExpirationAlertConfig` fields for names that would normalize to the
  same underscore-stripped, case-folded string — none collide.

Tagging every field would be more explicit/local to the struct, but given
its size and rate of change, it trades a one-time fix for an ongoing
maintenance burden that's easy to forget.